### PR TITLE
Nixed flaky curl call used to install poetry in CI (GitHub)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,11 @@ jobs:
         python-version: '3.12'
     
     - name: Install Poetry
-      run: |
-        curl -sSL https://install.python-poetry.org | python3 -
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
+      uses: snok/install-poetry@v1
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+        installer-parallel: true
     
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary

Removed curl-based poetry install from CI

## Changes

- Went with a more mature/less flaky way of loading poetry in GitHub action YAML

## Type of Change

- [ ] Performance improvement
- [ ] Test additions/improvements

## Testing

How was this tested?
Manual testing