### PR TITLE
Feature shorten news and tavily data

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -203,6 +203,10 @@ class Config:
     # Default: 15 RPM (free tier) - Set GEMINI_RPM_LIMIT in .env to override
     gemini_rpm_limit: int = int(os.environ.get("GEMINI_RPM_LIMIT", "15"))
 
+    # Tavily search result truncation (prevents token bloat from web searches)
+    # Default: 7000 chars (~1750 tokens) per search result
+    tavily_max_chars: int = int(os.environ.get("TAVILY_MAX_CHARS", "7000"))
+
     chroma_persist_directory: str = os.environ.get("CHROMA_PERSIST_DIR", "./chroma_db")
     environment: str = os.environ.get("ENVIRONMENT", "dev")
     


### PR DESCRIPTION
Capped Tavily, truncated news

## Summary

Capped Tavily results to 7000 chars, truncated news

## Changes

- If news analyst comes back with > 300 chars, summarization happens
- Tavily (which was uncapped in many places) is now capped at 7,000 chars per result

## Type of Change

- [ ] Performance improvement (fundamentals analyst now goes right to deep model)

## Testing

How was this tested?  Manually:  poetry run pytest tests/ -v
