### PR TITLE
Parallelized risk agents

### DIFF
--- a/src/llms.py
+++ b/src/llms.py
@@ -365,6 +365,11 @@ def get_consultant_llm(
     """
     global _consultant_llm_instance
 
+    # Skip consultant in quick mode for performance
+    if quick_mode:
+        logger.info("Consultant LLM skipped in quick mode for performance")
+        return None
+
     # Check if consultant is enabled (via config, not os.environ)
     if not config.enable_consultant:
         logger.info("Consultant LLM disabled via ENABLE_CONSULTANT=false")

--- a/src/main.py
+++ b/src/main.py
@@ -430,7 +430,7 @@ def save_results_to_file(result: dict, ticker: str) -> Path:
                 "neutral_perspective": result.get("risk_debate_state", {}).get(
                     "current_neutral_response", ""
                 ),
-                "debate_rounds": result.get("risk_debate_state", {}).get("count", 0),
+                "debate_rounds": 1,  # Risk analysts run in parallel (1 round each)
             }
         },
         "final_decision": {
@@ -537,16 +537,10 @@ async def run_analysis(ticker: str, quick_mode: bool) -> dict | None:
             investment_plan="",
             trader_investment_plan="",
             risk_debate_state=RiskDebateState(
-                risky_history="",
-                safe_history="",
-                neutral_history="",
-                history="",
                 latest_speaker="",
                 current_risky_response="",
                 current_safe_response="",
                 current_neutral_response="",
-                judge_decision="",
-                count=0,
             ),
             final_trade_decision="",
             tools_called={},

--- a/src/report_generator.py
+++ b/src/report_generator.py
@@ -364,14 +364,29 @@ Re-run analysis with verbose logging: `poetry run python -m src.main --ticker {s
             if isinstance(risk_state, list):
                 risk_state = risk_state[-1] if risk_state else {}
 
-            risk_history = (
-                risk_state.get("history", "") if isinstance(risk_state, dict) else ""
-            )
-            if risk_history:
-                report_parts.append("## Risk Assessment\n\n")
-                report_parts.append(
-                    f"{self._clean_text(risk_history, demote_headers=True)}\n\n"
-                )
+            if isinstance(risk_state, dict):
+                # Read from dedicated fields (parallel-safe architecture)
+                risky = risk_state.get("current_risky_response", "")
+                safe = risk_state.get("current_safe_response", "")
+                neutral = risk_state.get("current_neutral_response", "")
+
+                if risky or safe or neutral:
+                    report_parts.append("## Risk Assessment\n\n")
+                    if risky:
+                        report_parts.append("### Risky Analyst (Aggressive)\n\n")
+                        report_parts.append(
+                            f"{self._clean_text(risky, demote_headers=True)}\n\n"
+                        )
+                    if safe:
+                        report_parts.append("### Safe Analyst (Conservative)\n\n")
+                        report_parts.append(
+                            f"{self._clean_text(safe, demote_headers=True)}\n\n"
+                        )
+                    if neutral:
+                        report_parts.append("### Neutral Analyst (Balanced)\n\n")
+                        report_parts.append(
+                            f"{self._clean_text(neutral, demote_headers=True)}\n\n"
+                        )
 
         # Footer
         mode_suffix = " (Quick Models)" if self.quick_mode else ""

--- a/tests/test_consultant_edge_cases.py
+++ b/tests/test_consultant_edge_cases.py
@@ -418,7 +418,7 @@ class TestBackwardsCompatibility:
             "investment_plan": "BUY",
             "consultant_review": "",  # Empty
             "trader_investment_plan": "Trader",
-            "risk_debate_state": {"history": "Risk"},
+            "risk_debate_state": {"current_risky_response": "Risk assessment"},
         }
 
         consultant = state.get("consultant_review", "")

--- a/tests/test_consultant_integration.py
+++ b/tests/test_consultant_integration.py
@@ -449,19 +449,10 @@ class TestConsultantQuickMode:
         # Reset the global instance
         src.llms._consultant_llm_instance = None
 
-        with patch("langchain_openai.ChatOpenAI") as mock_chatgpt:
-            mock_chatgpt.return_value = MagicMock()
-
-            with patch("src.llms.config") as mock_config:
-                mock_config.enable_consultant = True
-                mock_config.consultant_quick_model = "gpt-4o-mini-test"
-                mock_config.get_openai_api_key.return_value = "test-key"
-                llm = get_consultant_llm(quick_mode=True)
-
-                assert llm is not None
-                mock_chatgpt.assert_called_once()
-                call_kwargs = mock_chatgpt.call_args[1]
-                assert call_kwargs["model"] == "gpt-4o-mini-test"
+        # quick_mode now skips the consultant entirely for performance
+        # (saves ~34 seconds per analysis)
+        llm = get_consultant_llm(quick_mode=True)
+        assert llm is None, "quick_mode should skip consultant for performance"
 
         # Reset for other tests
         src.llms._consultant_llm_instance = None

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -385,11 +385,15 @@ class TestGenerateReport:
         assert "MACD: Bullish" in report
 
     def test_generate_report_risk_state_dict(self):
-        """Test risk assessment from nested dict."""
+        """Test risk assessment from nested dict with dedicated fields."""
         reporter = QuietModeReporter("AMD")
         result_dict = {
             "final_trade_decision": "Action: HOLD",
-            "risk_debate_state": {"history": "Risky: High risk\nSafe: Low risk"},
+            "risk_debate_state": {
+                "current_risky_response": "High risk tolerance recommended",
+                "current_safe_response": "Low risk approach preferred",
+                "current_neutral_response": "",
+            },
         }
 
         report = reporter.generate_report(result_dict)
@@ -403,16 +407,19 @@ class TestGenerateReport:
         result_dict = {
             "final_trade_decision": "Action: BUY",
             "risk_debate_state": [
-                {"history": "Old debate"},
-                {"history": "Latest debate: This is current"},
+                {"current_risky_response": "Old risky view"},
+                {
+                    "current_risky_response": "Latest risky: This is current",
+                    "current_safe_response": "Latest safe view",
+                },
             ],
         }
 
         report = reporter.generate_report(result_dict)
 
         assert "Risk Assessment" in report
-        assert "Latest debate" in report
-        assert "Old debate" not in report
+        assert "Latest" in report
+        assert "Old risky" not in report
 
     def test_generate_report_timestamp_format(self):
         """Test timestamp is properly formatted."""
@@ -436,7 +443,11 @@ class TestGenerateReport:
             "news_report": "New product launch",
             "investment_plan": "Recommend BUY",
             "trader_investment_plan": "Entry: $300",
-            "risk_debate_state": {"history": "Moderate risk"},
+            "risk_debate_state": {
+                "current_risky_response": "Moderate risk acceptable",
+                "current_safe_response": "",
+                "current_neutral_response": "",
+            },
         }
 
         report = reporter.generate_report(result_dict)

--- a/tests/test_response_content_extraction.py
+++ b/tests/test_response_content_extraction.py
@@ -619,7 +619,7 @@ class TestRegressionDetection:
             "investment_plan": "Buy recommendation",
             "consultant_review": "",
             "trader_investment_plan": "Execute buy",
-            "risk_debate_state": {"history": "Risk acceptable"},
+            "risk_debate_state": {"current_risky_response": "Risk acceptable"},
             "company_of_interest": "1681.HK",
             "company_name": "CONSUN PHARMA",
             "red_flags": [],
@@ -660,24 +660,28 @@ class TestRegressionDetection:
         }
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
 
-        node = create_risk_debater_node(mock_llm, "conservative_risk")
+        node = create_risk_debater_node(mock_llm, "safe_analyst")
 
         state = {
             "trader_investment_plan": "Buy 1681.HK",
             "consultant_review": "",
-            "risk_debate_state": {"history": "", "count": 0},
+            "risk_debate_state": {
+                "current_risky_response": "",
+                "current_safe_response": "",
+                "current_neutral_response": "",
+            },
             "company_of_interest": "1681.HK",
         }
         config = {"configurable": {}}
 
         result = await node(state, config)
 
-        # THE CRITICAL ASSERTION
+        # THE CRITICAL ASSERTION - now checks dedicated field
         risk_state = result.get("risk_debate_state", {})
-        history = risk_state.get("history", "")
+        safe_response = risk_state.get("current_safe_response", "")
 
-        assert isinstance(history, str), (
-            f"REGRESSION DETECTED: risk history is {type(history).__name__}, expected str. "
+        assert isinstance(safe_response, str), (
+            f"REGRESSION DETECTED: safe_response is {type(safe_response).__name__}, expected str. "
             f"Check that extract_string_content(response.content) is called in create_risk_debater_node()."
         )
 

--- a/tests/test_state_corruption_recovery.py
+++ b/tests/test_state_corruption_recovery.py
@@ -795,21 +795,21 @@ class TestEndToEndInformationFlow:
             Entry: Market order at $120
             Stop loss: $95 (20% downside)
             """,
-            # Risk debate (from risk team)
+            # Risk debate (from risk team - parallel-safe dedicated fields)
             "risk_debate_state": {
-                "history": """
-                RISK TEAM DEBATE
-
+                "current_safe_response": """
                 Conservative Risk Analyst: MODERATE risk
                 - Leverage at 45% is manageable
                 - Stop loss: $95 protects downside
-
+                """,
+                "current_neutral_response": """
                 Neutral Risk Analyst: MODERATE risk
                 - Agrees with conservative assessment
-
+                """,
+                "current_risky_response": """
                 Aggressive Risk Analyst: LOW risk
                 - Strong growth justifies position
-                """
+                """,
             },
             # Red-flag pre-screening results
             "pre_screening_result": "PASS",


### PR DESCRIPTION
Parallelized risk agents - and bug fixes

## Summary

Parallelized risk agents and bypassed consultant when --quick is supplied (performance enhancements)

## Changes

- Parallelized risk agents
- Had them all save their information separately - no message pollution
- Fixed other agents (tool callers) that were polluting mesages in the same way
- Streamlined reducer code that merges dict data

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Performance improvement
- [ ] Test additions/improvements

## Testing

How was this tested?  Manual run of poetry run pytest tests/ -v
