### PR TITLE
Feat untrusted content hooks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ permissions:
 
 env:
   REGISTRY_NAME: tradingsystem  # ⚠️  CHANGE THIS! Use your own Azure Container Registry name
-  IMAGE_NAME: trading-system
+  IMAGE_NAME: investment-agent
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════════

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -207,7 +207,7 @@ jobs:
 
       # Scan repository for vulnerabilities in dependencies, misconfigurations, secrets
       - name: Run Trivy vulnerability scanner (repo mode)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'  # Filesystem scan (entire repository)
           scan-ref: '.'    # Scan current directory
@@ -239,7 +239,7 @@ jobs:
       # Generate human-readable report for PR comments
       - name: Run Trivy for PR comment (table format)
         if: github.event_name == 'pull_request'
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -303,7 +303,7 @@ jobs:
 
       # Scan Python dependencies specifically (more focused than repo scan)
       - name: Run Trivy on Python dependencies
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -357,7 +357,7 @@ jobs:
       # Scan the built Docker image for vulnerabilities
       - name: Run Trivy on Docker image
         if: steps.dockerfile_check.outputs.exists == 'true'
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'image'  # Scan Docker image
           image-ref: 'investment-agent:${{ github.sha }}'
@@ -392,7 +392,7 @@ jobs:
       # Generate table report for Docker scan
       - name: Run Trivy for Docker summary
         if: steps.dockerfile_check.outputs.exists == 'true'
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           scan-type: 'image'
           image-ref: 'investment-agent:${{ github.sha }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.5] - 2026-03-21
+
+### Added
+
+- **Content Inspection Hook** — `src/tooling/inspector.py` / `inspection_service.py` / `inspection_hook.py`: policy layer that potentially sanitises every tool output before it reaches LLM context. `NullInspector` default (zero overhead); swap backend via `configure_content_inspection()` at startup.
+- **Per-Agent Output Budgets** — `src/llm_budgets.py` centralises fractional `max_tokens` caps per agent; `src/agents/output_validation.py` coerces and validates DATA_BLOCK numeric fields.
+
+### Fixed
+
+- **`DO NOT INITIATE` Restart Parsing** — `run_pipeline.sh` now correctly recognises `DO NOT INITIATE` verdicts when resuming interrupted batch runs; previously they were re-queued as unresolved.
+- **Exchange-Qualified Ticker Propagation** — `src/ticker_policy.py` centralises exchange-suffix rules; fixes cross-exchange base-symbol clashes in the data fetcher and pipeline verdict parser.
+- **Trivy CI Pin** — `trivy-action` bumped `0.28.0` → `0.35.0`; the old tag did not exist, silently blocking all Trivy jobs before any scan ran.
+
+### Changed
+
+- **Container Hardening** — `Dockerfile`, `docker-compose.yml`, and `scripts/check-environment.sh` updated for Podman-first runtime; `README.md` local-container setup docs expanded.
+
 ## [3.9.4] - 2026-03-19
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,9 @@ RUN poetry install --only main --no-root --no-interaction --no-ansi
 # ────────────────────────────────────────────────────────────────────────────
 FROM python:3.12-slim AS runtime
 
-# Install only runtime dependencies (SQLite for ChromaDB)
+# Install only runtime dependencies (SQLite for ChromaDB + bash for scripts)
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
     libsqlite3-0 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -60,29 +61,40 @@ WORKDIR /app
 
 # Copy installed packages from builder stage
 COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
-COPY --from=builder /usr/local/bin /usr/local/bin
 
 # Copy application code
 COPY --chown=agent:agent src/ ./src/
 COPY --chown=agent:agent prompts/ ./prompts/
+COPY --chown=agent:agent scripts/ ./scripts/
 
-# Create directories for ChromaDB persistence and results
-RUN mkdir -p /app/chroma_db /app/results /app/scratch \
+# Normalise source-file permissions: COPY preserves host mode bits, so
+# directories that are mode 700 on the host would be unreadable by any user
+# other than the owner. a+rX makes all source/prompts/scripts files readable
+# and directories traversable regardless of what the host had.
+RUN chmod -R a+rX /app/src /app/prompts /app/scripts
+
+# Create directories for bind-mounted local persistence
+RUN mkdir -p /app/chroma_db /app/results /app/data_cache /app/images /app/scratch \
     && chown -R agent:agent /app
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
+    HOME=/app \
+    INVESTMENT_AGENT_CONTAINER=1 \
     CHROMA_PERSIST_DIRECTORY=/app/chroma_db \
+    CHROMA_PERSIST_DIR=/app/chroma_db \
+    RESULTS_DIR=/app/results \
+    DATA_CACHE_DIR=/app/data_cache \
+    IMAGES_DIR=/app/images \
     ANONYMIZED_TELEMETRY=False
 
 # Switch to non-root user
 USER agent
 
-# Health check - verify Python imports work (no HTTP server needed)
-# This checks that the application can at least import its main module
+# Health check - verify Python and the lightweight config module import cleanly
 HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --retries=3 \
-    CMD python -c "import sys; from src.main import main; sys.exit(0)" || exit 1
+    CMD python -c "import src.config" || exit 1
 
 # Entrypoint uses module syntax for clean imports
 ENTRYPOINT ["python", "-m", "src.main"]

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,16 @@
 # Variables
 PYTHON := python3
 POETRY := poetry
+# Prefer Podman locally via `make ... DOCKER=podman` if available.
 DOCKER ?= docker
+COMPOSE ?= $(DOCKER) compose
 TICKER ?= AAPL
+CONTAINER_MOUNTS = \
+	-v "$(CURDIR)/results:/app/results" \
+	-v "$(CURDIR)/chroma_db:/app/chroma_db" \
+	-v "$(CURDIR)/data_cache:/app/data_cache" \
+	-v "$(CURDIR)/images:/app/images" \
+	-v "$(CURDIR)/scratch:/app/scratch"
 
 # Colors for output
 BLUE := \033[0;34m
@@ -28,7 +36,7 @@ help: ## Show this help message
 	@echo "  make install          # Install dependencies"
 	@echo "  make run-quick TICKER=AAPL  # Quick analysis for AAPL"
 	@echo "  make test             # Run tests"
-	@echo "  make docker-run TICKER=NVDA # Run with Docker"
+	@echo "  make docker-run TICKER=NVDA DOCKER=podman # Preferred local container path"
 
 install: ## Install dependencies using Poetry
 	@echo "$(BLUE)Installing dependencies...$(NC)"
@@ -128,24 +136,27 @@ docker-build: ## Build Docker image
 
 docker-run: ## Run with Docker (default: AAPL quick)
 	@echo "$(BLUE)Running Docker container for $(TICKER)...$(NC)"
-	$(DOCKER) run --rm --env-file .env investment-agent:latest --ticker $(TICKER) --quick
+	@mkdir -p results chroma_db data_cache images scratch
+	$(DOCKER) run --rm --env-file .env $(CONTAINER_MOUNTS) investment-agent:latest --ticker $(TICKER) --quick --output results/$(TICKER).md
 
 docker-run-deep: ## Run deep analysis with Docker (default: AAPL)
 	@echo "$(BLUE)Running Docker container for $(TICKER) (deep mode)...$(NC)"
-	$(DOCKER) run --rm --env-file .env investment-agent:latest --ticker $(TICKER)
+	@mkdir -p results chroma_db data_cache images scratch
+	$(DOCKER) run --rm --env-file .env $(CONTAINER_MOUNTS) investment-agent:latest --ticker $(TICKER) --output results/$(TICKER).md
 
 docker-shell: ## Open shell in Docker container
 	@echo "$(BLUE)Opening shell in Docker container...$(NC)"
-	$(DOCKER) run --rm -it --env-file .env --entrypoint /bin/bash investment-agent:latest
+	@mkdir -p results chroma_db data_cache images scratch
+	$(DOCKER) run --rm -it --env-file .env $(CONTAINER_MOUNTS) --entrypoint /bin/bash investment-agent:latest
 
 docker-compose-up: ## Start services with docker-compose
-	@echo "$(BLUE)Starting services with docker-compose...$(NC)"
-	docker-compose up -d
+	@echo "$(BLUE)Starting services with compose...$(NC)"
+	$(COMPOSE) up -d
 	@echo "$(GREEN)Services started!$(NC)"
 
 docker-compose-down: ## Stop services with docker-compose
 	@echo "$(BLUE)Stopping services...$(NC)"
-	docker-compose down
+	$(COMPOSE) down
 	@echo "$(GREEN)Services stopped!$(NC)"
 
 env-setup: ## Copy .env.example to .env

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ The pipeline pauses before each AI stage to show a summary (ticker count, estima
 | `-y, --yes` | Skip all confirmation prompts (for cron/CI/overnight runs) |
 | `--skip-scrape FILE` | Skip Stage 0 scraping; use an existing ticker list file |
 | `--stage N` | Run only stage N (0=scrape, 1=quick-screen, 2=full analysis) |
+| `--run-date DATE` | Force the pipeline/output date for cross-day resume when filenames were copied or renamed |
 | `--buys-file FILE` | Explicit BUY list to use for Stage 2 (see resumption notes below) |
 | `--cooldown N` | Seconds between analyses (default: 60 for free tier, 10 for paid) |
 | `--quick` | Pass `--quick` flag to each analysis (1 debate round, faster) |
@@ -273,18 +274,37 @@ Output lands in `scratch/`: quick-screen reports (`*_quick.md`), full reports fo
 The pipeline has built-in resumability: any ticker whose output file already contains a verdict line is skipped automatically. To resume:
 
 ```bash
+# Same-day resume for Stage 1 or Stage 2
+# Re-run the same command family without --force; completed outputs are skipped
+./scripts/run_pipeline.sh --stage 1 --skip-scrape scratch/gems_2026-03-02.txt
+
 # Same-day resume (pipeline ran and was interrupted today)
 # Just re-run with --stage 2 — it finds today's buys file and skips completed tickers
 ./scripts/run_pipeline.sh --stage 2
+
+# Cross-day resume for Stage 1
+# Point --skip-scrape at the original gems_YYYY-MM-DD.txt file from the interrupted run.
+# The script now derives the run date from that filename and reuses the matching
+# quick-screen outputs instead of looking for today's files.
+./scripts/run_pipeline.sh --stage 1 --skip-scrape scratch/gems_2026-03-02.txt
 
 # Cross-day resume (pipeline started yesterday, interrupted, resuming today)
 # Use --buys-file to point at yesterday's BUY list.
 # The script detects the date in the filename and matches output files correctly —
 # without this, it would look for today's output files and re-analyze everything.
 ./scripts/run_pipeline.sh --stage 2 --buys-file scratch/buys_2026-03-02.txt
+
+# If you copied or renamed the ticker list / BUY list and the original date is no
+# longer in the filename, force the original run date explicitly:
+./scripts/run_pipeline.sh --stage 1 --skip-scrape scratch/gems_2026-03-20.txt --run-date 2026-03-02
 ```
 
-Without `--buys-file` on a cross-day resume, the script looks for today's BUY list and stops. Point it at the earlier `buys_YYYY-MM-DD.txt` file to reuse the correct outputs.
+Subtle but important:
+
+- Stage 1 resumability depends on the original run date because quick outputs are named `README-<ticker>-YYYY-MM-DD_quick.md`.
+- Stage 2 resumability depends on the original run date because full outputs and `buys_YYYY-MM-DD.txt` are date-scoped the same way.
+- If you keep the original `gems_YYYY-MM-DD.txt` / `buys_YYYY-MM-DD.txt` filenames, the script can infer the correct date automatically.
+- If you copy or rename those files, use `--run-date YYYY-MM-DD` so the script checks the correct output files instead of today's.
 
 ### Configuring API Rate Limits
 

--- a/README.md
+++ b/README.md
@@ -806,6 +806,18 @@ Read it this way:
 - `src/data/`, `src/validators/`, `src/memory.py`, and `src/charts/` are shared subsystems used by the graph and reporting layers.
 - `src/ibkr/` is adjacent to, not embedded inside, the single-ticker analysis flow.
 
+### Appendix: Untrusted Content Inspection
+
+If you need to screen untrusted external content before it reaches LLM context, the main insertion points now live under `src/tooling/`:
+
+- `src/tooling/inspection_service.py` owns the backend-agnostic inspection service.
+- `src/tooling/inspection_hook.py` attaches that inspection pass to the shared tool execution path.
+- `src/main.py` wires inspection from config at startup.
+
+Some high-risk direct-ingress paths also call the inspection service explicitly before returning LLM-facing text, including Tavily/search helpers, editor fetch tools, selected news/social inputs, and fetcher gap-fill paths.
+
+The design is intentionally pluggable. Today the default backend is a no-op, but the seam is meant to support remote HTTP services, local Python libraries, subprocess-based scanners, or local/offline model wrappers without changing calling code.
+
 ---
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -228,6 +228,129 @@ poetry run python -u -m src.main --ticker 0005.HK --output scratch/report.md >sc
 poetry run pytest tests/ -v
 ```
 
+### Optional: Local Container Mode
+
+Manual repo mode remains the default. If you prefer stronger runtime isolation, you can also run the project locally in a container. For local use, prefer **Podman** over Docker. It has a tighter default security posture and is the better fit for most developers who are wary of giving a daemon broad control of their workstation.
+
+This container mode is intentionally secondary: it uses **bind mounts** so the container reads and writes the same host directories that manual mode uses.
+
+What persists on the host in container mode:
+
+- `results/` -> analysis JSONs and report outputs
+- `chroma_db/` -> ChromaDB-backed memory state
+- `data_cache/` -> cached data fetches
+- `images/` -> generated charts and image assets
+- `scratch/` -> pipeline artifacts, logs, and resumability files
+
+Important:
+
+- Manual mode and container mode can share the same host directories safely.
+- Embedded Chroma is still a **single-writer local store**. Do not run multiple concurrently writing containers against the same `chroma_db/`.
+- The image is built from the repo root. During `docker build` / `podman build`, the Dockerfile copies `src/` into `/app/src`, `prompts/` into `/app/prompts`, and `scripts/` into `/app/scripts`. That is how both the application code and the operational scripts get into the image.
+- The runtime image does **not** include Poetry. Shell scripts in the image call plain `python ...` so they work both in a container and in an activated local venv.
+- On macOS with Podman, use `--user "$(id -u):$(id -g)"` in the examples below. `--userns=keep-id` is not sufficient there for bind-mounted write access.
+
+Build the image:
+
+```bash
+# Preferred:
+podman build -t investment-agent .
+
+# Secondary option:
+docker build -t investment-agent .
+```
+
+One-off analysis through Podman:
+
+```bash
+podman run --rm \
+  --env-file .env \
+  --user "$(id -u):$(id -g)" \
+  -v "$PWD/results:/app/results:Z" \
+  -v "$PWD/chroma_db:/app/chroma_db:Z" \
+  -v "$PWD/data_cache:/app/data_cache:Z" \
+  -v "$PWD/images:/app/images:Z" \
+  -v "$PWD/scratch:/app/scratch:Z" \
+  investment-agent \
+  --ticker 0005.HK --output results/0005.HK.md
+```
+
+Docker equivalent:
+
+```bash
+docker run --rm \
+  --env-file .env \
+  -v "$PWD/results:/app/results" \
+  -v "$PWD/chroma_db:/app/chroma_db" \
+  -v "$PWD/data_cache:/app/data_cache" \
+  -v "$PWD/images:/app/images" \
+  -v "$PWD/scratch:/app/scratch" \
+  investment-agent \
+  --ticker 0005.HK --output results/0005.HK.md
+```
+
+Containerized pipeline:
+
+```bash
+podman run --rm \
+  --entrypoint bash \
+  --env-file .env \
+  --user "$(id -u):$(id -g)" \
+  -v "$PWD/results:/app/results:Z" \
+  -v "$PWD/chroma_db:/app/chroma_db:Z" \
+  -v "$PWD/data_cache:/app/data_cache:Z" \
+  -v "$PWD/images:/app/images:Z" \
+  -v "$PWD/scratch:/app/scratch:Z" \
+  investment-agent \
+  scripts/run_pipeline.sh --stage 1 --skip-scrape scratch/gems_2026-03-20.txt
+```
+
+Docker equivalent:
+
+```bash
+docker run --rm \
+  --entrypoint bash \
+  --env-file .env \
+  -v "$PWD/results:/app/results" \
+  -v "$PWD/chroma_db:/app/chroma_db" \
+  -v "$PWD/data_cache:/app/data_cache" \
+  -v "$PWD/images:/app/images" \
+  -v "$PWD/scratch:/app/scratch" \
+  investment-agent \
+  scripts/run_pipeline.sh --stage 1 --skip-scrape scratch/gems_2026-03-20.txt
+```
+
+Containerized portfolio manager:
+
+```bash
+podman run --rm \
+  --entrypoint python \
+  --env-file .env \
+  --user "$(id -u):$(id -g)" \
+  -v "$PWD/results:/app/results:Z" \
+  -v "$PWD/chroma_db:/app/chroma_db:Z" \
+  -v "$PWD/data_cache:/app/data_cache:Z" \
+  -v "$PWD/images:/app/images:Z" \
+  -v "$PWD/scratch:/app/scratch:Z" \
+  investment-agent \
+  scripts/portfolio_manager.py --read-only
+```
+
+Docker equivalent:
+
+```bash
+docker run --rm \
+  --entrypoint python \
+  --env-file .env \
+  -v "$PWD/results:/app/results" \
+  -v "$PWD/chroma_db:/app/chroma_db" \
+  -v "$PWD/data_cache:/app/data_cache" \
+  -v "$PWD/images:/app/images" \
+  -v "$PWD/scratch:/app/scratch" \
+  investment-agent \
+  scripts/portfolio_manager.py --read-only
+```
+
 ### Automated Screening Pipeline (Fastest Path to Gems)
 
 Find undervalued international stocks end-to-end — no manual steps:
@@ -740,18 +863,26 @@ Edge case testing matters here because the runtime depends on unreliable externa
 
 ## Deployment (Educational Reference)
 
-### Docker Support
+### Container Support
 
-Production-ready **multi-stage Dockerfile** (Poetry 2.x, non-root user, ~40% smaller images):
+The repo includes a multi-stage container image for optional local execution. For most local setups, prefer **Podman** and use the bind-mounted workflows in [Optional: Local Container Mode](#optional-local-container-mode). Docker still works, but it is the secondary path here.
 
 ```bash
-# Build and run
-docker build -t trading-system .
-docker run --env-file .env trading-system --ticker 0005.HK --quick
-
-# Or use docker-compose
-docker compose run --rm investment-agent --ticker 7203.T
+# Preferred local build/run path
+podman build -t investment-agent .
+podman run --rm \
+  --env-file .env \
+  --user "$(id -u):$(id -g)" \
+  -v "$PWD/results:/app/results:Z" \
+  -v "$PWD/chroma_db:/app/chroma_db:Z" \
+  -v "$PWD/data_cache:/app/data_cache:Z" \
+  -v "$PWD/images:/app/images:Z" \
+  -v "$PWD/scratch:/app/scratch:Z" \
+  investment-agent \
+  --ticker 0005.HK --quick --output results/0005.HK.md
 ```
+
+For Docker equivalents, `run_pipeline.sh`, and `portfolio_manager.py`, see [Optional: Local Container Mode](#optional-local-container-mode).
 
 ### Azure Container Instances (Terraform)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
 
     # Or specify environment variables directly
     environment:
-      # Note: Model selection is hardcoded in src/llms.py
-      # QUICK_MODEL and DEEP_MODEL env vars are ignored
+      # Model selection overrides the repo defaults in src/config.py
+      # Set QUICK_MODEL / DEEP_MODEL here if you want different runtime defaults
 
       # Logging
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
@@ -24,6 +24,10 @@ services:
       # ChromaDB
       - ANONYMIZED_TELEMETRY=False
       - CHROMA_PERSIST_DIRECTORY=/app/chroma_db
+      - CHROMA_PERSIST_DIR=/app/chroma_db
+      - RESULTS_DIR=/app/results
+      - DATA_CACHE_DIR=/app/data_cache
+      - IMAGES_DIR=/app/images
 
       # LangSmith (optional)
       - LANGSMITH_TRACING=${LANGSMITH_TRACING:-false}
@@ -32,13 +36,13 @@ services:
       - GRPC_VERBOSITY=ERROR
       - GRPC_TRACE=
 
-    # Volume mounts for persistence
+    # Local bind mounts so container mode and manual mode share the same state
     volumes:
-      # Persist ChromaDB data
-      - chroma-data:/app/chroma_db
-
-      # Optional: Mount local code for development
-      # - ./src:/app/src:ro
+      - ./results:/app/results
+      - ./chroma_db:/app/chroma_db
+      - ./data_cache:/app/data_cache
+      - ./images:/app/images
+      - ./scratch:/app/scratch
 
     # Resource limits
     deploy:
@@ -49,12 +53,6 @@ services:
         reservations:
           cpus: '1.0'
           memory: 2G
-
-    # Restart policy
-    restart: unless-stopped
-
-    # Network mode
-    network_mode: bridge
 
     # Command override (examples)
     # Uncomment one of these or override at runtime
@@ -102,16 +100,6 @@ services:
   #     - agent-network
   #   depends_on:
   #     - prometheus
-
-volumes:
-  chroma-data:
-    driver: local
-
-  # Uncomment if enabling observability stack
-  # prometheus-data:
-  #   driver: local
-  # grafana-data:
-  #   driver: local
 
 networks:
   agent-network:

--- a/scripts/check-environment.sh
+++ b/scripts/check-environment.sh
@@ -31,6 +31,29 @@ print_error() {
     echo -e "${RED}[✗]${NC} $1"
 }
 
+resolve_python_cmd() {
+    if [[ -n "${INVESTMENT_AGENT_CONTAINER:-}" ]] || [[ -f "/.dockerenv" ]] || [[ -f "/run/.containerenv" ]]; then
+        PYTHON_CMD=(python)
+        PYTHON_CMD_DISPLAY="python"
+        return
+    fi
+
+    if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+        PYTHON_CMD=(python)
+        PYTHON_CMD_DISPLAY="python"
+        return
+    fi
+
+    if command -v poetry &> /dev/null; then
+        PYTHON_CMD=(poetry run python)
+        PYTHON_CMD_DISPLAY="poetry run python"
+        return
+    fi
+
+    PYTHON_CMD=()
+    PYTHON_CMD_DISPLAY=""
+}
+
 echo ""
 echo "════════════════════════════════════════════════════════════"
 echo "  Multi-Agent Trading System - Environment Check"
@@ -113,6 +136,7 @@ echo ""
 
 # Check Python/Poetry
 print_info "Checking Python environment..."
+resolve_python_cmd
 
 if command -v python3 &> /dev/null; then
     python_version=$(python3 --version 2>&1 | grep -oE '[0-9]+\.[0-9]+' | head -1)
@@ -122,12 +146,16 @@ else
     errors=$((errors + 1))
 fi
 
-if command -v poetry &> /dev/null; then
-    poetry_version=$(poetry --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-    print_success "Poetry $poetry_version found"
+if [[ -n "${PYTHON_CMD_DISPLAY:-}" ]]; then
+    if [[ "$PYTHON_CMD_DISPLAY" == "poetry run python" ]]; then
+        poetry_version=$(poetry --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        print_success "Poetry $poetry_version found"
+    else
+        print_success "Runtime command available: $PYTHON_CMD_DISPLAY"
+    fi
 else
-    print_error "Poetry not found"
-    print_info "Install from: https://python-poetry.org/docs/#installation"
+    print_error "Poetry not found and no active venv/container runtime detected"
+    print_info "Install Poetry from: https://python-poetry.org/docs/#installation"
     errors=$((errors + 1))
 fi
 
@@ -152,9 +180,9 @@ else
     fi
     echo ""
     print_info "You're ready to run analysis:"
-    echo "  ./scripts/run-analysis.sh --ticker AAPL"
+    echo "  ${PYTHON_CMD_DISPLAY} -m src.main --ticker AAPL"
     echo ""
     print_info "Or run the health check:"
-    echo "  poetry run python src/health_check.py"
+    echo "  ${PYTHON_CMD_DISPLAY} src/health_check.py"
     echo ""
 fi

--- a/scripts/portfolio_manager.py
+++ b/scripts/portfolio_manager.py
@@ -6,7 +6,7 @@ Compares live IBKR positions against the equity evaluator's latest
 analysis recommendations. Produces position-aware BUY/SELL/HOLD/TRIM/REVIEW
 actions that account for existing holdings.
 
-Usage (requires Poetry venv — either activate it or prefix with `poetry run`):
+Usage (manual repo mode: use Poetry or an activated venv):
     poetry run python scripts/portfolio_manager.py --test-auth          # Verify IBKR credentials work
     poetry run python scripts/portfolio_manager.py                      # Report only
     poetry run python scripts/portfolio_manager.py --recommend          # + order suggestions
@@ -16,7 +16,10 @@ Usage (requires Poetry venv — either activate it or prefix with `poetry run`):
     # Or activate once: source .venv/bin/activate
     # Then plain `python scripts/portfolio_manager.py` works for the session.
 
-Requires: poetry install
+    # Local container mode (inside the runtime image, Poetry is not installed):
+    python scripts/portfolio_manager.py --read-only
+
+Requires: project dependencies installed (manual repo mode typically uses `poetry install`)
 """
 
 from __future__ import annotations
@@ -25,6 +28,7 @@ import argparse
 import asyncio
 import getpass
 import json
+import os
 import sys
 import textwrap
 from datetime import datetime
@@ -50,6 +54,28 @@ from src.ibkr.reconciler import (
 _IBKR_OAUTH_PORTAL = (
     "https://ndcdyn.interactivebrokers.com/sso/Login?action=OAUTH&RL=1&ip2loc=US"
 )
+
+
+def _python_command_prefix() -> str:
+    """Return the user-facing Python launcher for the current runtime."""
+    if (
+        os.getenv("INVESTMENT_AGENT_CONTAINER")
+        or os.getenv("VIRTUAL_ENV")
+        or Path("/.dockerenv").exists()
+        or Path("/run/.containerenv").exists()
+    ):
+        return "python"
+    return "poetry run python"
+
+
+def _analysis_command(ticker: str) -> str:
+    return f"{_python_command_prefix()} -m src.main --ticker {ticker}"
+
+
+def _portfolio_manager_command(*args: str) -> str:
+    suffix = " ".join(args).strip()
+    base = f"{_python_command_prefix()} scripts/portfolio_manager.py"
+    return f"{base} {suffix}".strip()
 
 
 def _prompt_for_missing_secret(config) -> None:
@@ -1286,9 +1312,7 @@ def format_report(
                 if "." not in _run_t
                 else ""
             )
-            lines.append(
-                f"      poetry run python -m src.main --ticker {_run_t}{_sfx_warn}"
-            )
+            lines.append(f"      {_analysis_command(_run_t)}{_sfx_warn}")
         lines.append("")
 
     def _norm_reason(r: str) -> str:
@@ -1955,7 +1979,7 @@ def format_report(
             _sfx_warn = (
                 "  ← ⚠ exchange unknown, verify suffix" if "." not in _run_t else ""
             )
-            run_cmd = f"python -m src.main --ticker {_run_t}{_sfx_warn}"
+            run_cmd = f"{_analysis_command(_run_t)}{_sfx_warn}"
             lines.append(
                 f"  {'REVIEW':<6}  {_display_ticker(item):<12}  {reason_short}  →  {run_cmd}"
             )
@@ -2237,7 +2261,7 @@ def format_report(
                     f"  {_dstars}  score {_dscore:.0f}"
                     f"  H:{_dh}% G:{_dg}%"
                     f"  [{_dqty}]"
-                    f"  →  poetry run python -m src.main --ticker {_run_ticker_for(_di)}"
+                    f"  →  {_analysis_command(_run_ticker_for(_di))}"
                 )
             if _dips_in_flight:
                 lines.append(
@@ -2262,7 +2286,7 @@ def format_report(
                 lines.append(
                     f"    → ADD TO WATCHLIST  {_display_ticker(i)}"
                     f"  — analysis {i.analysis.analysis_date if i.analysis else '?'} says BUY{_quick_note}"
-                    f"  →  poetry run python -m src.main --ticker {_run_ticker_for(i)}"
+                    f"  →  {_analysis_command(_run_ticker_for(i))}"
                 )
             skipped = len(_cands_actionable) - len(strong_candidates)
             if skipped > 0:
@@ -2290,9 +2314,7 @@ def format_report(
                     "  (see DIP OPPORTUNITIES above)"
                 )
             lines.append("    → Run before placing any additional buys:")
-            lines.append(
-                "        poetry run python scripts/portfolio_manager.py --recommend"
-            )
+            lines.append(f"        {_portfolio_manager_command('--recommend')}")
             lines.append("")
 
         if upcoming_reviews:
@@ -2305,7 +2327,7 @@ def format_report(
                 )
                 lines.append(
                     f"    → {disp_sym:<14} expires {expires}  ({days_left}d remaining)"
-                    f"  →  poetry run python -m src.main --ticker {yf_t}{_sfx_warn}"
+                    f"  →  {_analysis_command(yf_t)}{_sfx_warn}"
                 )
             lines.append("")
 
@@ -2694,7 +2716,7 @@ def main() -> None:
     if not analyses:
         print(f"No analysis JSONs found in {results_dir}/", file=sys.stderr)
         print(
-            "Run some analyses first: poetry run python -m src.main --ticker 7203.T --output results/7203.T.md",
+            f"Run some analyses first: {_analysis_command('7203.T')} --output results/7203.T.md",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -82,6 +82,42 @@ format_duration() {
     fi
 }
 
+report_verdict_line() {
+    local file="$1"
+    awk '
+        /^# / {
+            line=$0
+            sub(/\r$/, "", line)
+            if (match(line, /: [A-Z_]+$/)) {
+                found = 1
+                print line
+                exit 0
+            }
+        }
+        END {
+            if (!found) {
+                exit 1
+            }
+        }
+    ' "$file" 2>/dev/null || true
+}
+
+extract_report_verdict() {
+    local file="$1"
+    local line
+    line=$(report_verdict_line "$file")
+    if [[ -n "$line" ]]; then
+        printf '%s\n' "${line##*: }"
+    fi
+}
+
+report_has_verdict_header() {
+    local file="$1"
+    local verdict
+    verdict=$(extract_report_verdict "$file")
+    [[ -n "$verdict" ]]
+}
+
 # --- Parse arguments ---
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -244,7 +280,7 @@ if [[ $START_STAGE -le 0 ]]; then
         [[ -z "$ticker" ]] && continue
         DASH=$(echo "$ticker" | tr '._' '-')
         OUTFILE="${SCRATCH}/README-${DASH}-${DATE}_quick.md"
-        if $FORCE || ! [[ -f "$OUTFILE" ]] || ! grep -qE '^# .*\): ' "$OUTFILE"; then
+        if $FORCE || ! [[ -f "$OUTFILE" ]] || ! report_has_verdict_header "$OUTFILE"; then
             STAGE1_TODO=$((STAGE1_TODO + 1))
         fi
     done < "$TICKER_LIST"
@@ -297,7 +333,7 @@ if [[ $START_STAGE -le 1 ]]; then
             [[ -z "$ticker" ]] && continue
             DASH=$(echo "$ticker" | tr '._' '-')
             OUTFILE="${SCRATCH}/README-${DASH}-${DATE}_quick.md"
-            if $FORCE || ! [[ -f "$OUTFILE" ]] || ! grep -qE '^# .*\): ' "$OUTFILE"; then
+            if $FORCE || ! [[ -f "$OUTFILE" ]] || ! report_has_verdict_header "$OUTFILE"; then
                 STAGE1_TODO=$((STAGE1_TODO + 1))
             fi
         done < "$TICKER_LIST"
@@ -340,7 +376,7 @@ if [[ $START_STAGE -le 1 ]]; then
         LOGFILE="${SCRATCH}/${DASH}-LOG-${DATE}_quick.txt"
 
         # Resumability: skip if output already has a verdict line
-        if ! $FORCE && [[ -f "$OUTFILE" ]] && grep -qE '^# .*\): ' "$OUTFILE"; then
+        if ! $FORCE && [[ -f "$OUTFILE" ]] && report_has_verdict_header "$OUTFILE"; then
             STAGE1_SKIPPED=$((STAGE1_SKIPPED + 1))
             info "SKIP $ticker (already done)"
             continue
@@ -354,7 +390,7 @@ if [[ $START_STAGE -le 1 ]]; then
             --quick --strict --no-charts --quiet --brief --no-memory \
             --output "$OUTFILE" \
             2> "$LOGFILE"; then
-            VERDICT=$(grep -m1 -E '^# .*\): ' "$OUTFILE" 2>/dev/null | sed 's/.*): //' | tr -d '\r')
+            VERDICT=$(extract_report_verdict "$OUTFILE")
             [[ -n "$VERDICT" ]] && success "$ticker done [Verdict=${VERDICT}]" || success "$ticker done"
         else
             fail "FAILED: $ticker (see $LOGFILE)"
@@ -398,33 +434,35 @@ if [[ $START_STAGE -le 1 ]]; then
             continue
         fi
 
-        # Title line (line 10) format: "# TICKER (Company Name): VERDICT"
-        if grep -qE '^# .*\): BUY$' "$OUTFILE"; then
-            echo "$ticker" >> "$BUY_LIST"
-            BUY_COUNT=$((BUY_COUNT + 1))
-            success "BUY: $ticker"
-        elif grep -qE '^# .*\): SELL' "$OUTFILE"; then
-            SELL_COUNT=$((SELL_COUNT + 1))
-            info "SELL: $ticker"
-        elif grep -qE '^# .*\): HOLD' "$OUTFILE"; then
-            HOLD_COUNT=$((HOLD_COUNT + 1))
-            info "HOLD: $ticker"
-        elif grep -qE '^# .*\): DO_NOT_INITIATE' "$OUTFILE"; then
-            SELL_COUNT=$((SELL_COUNT + 1))
-            info "DO_NOT_INITIATE: $ticker"
-        else
-            # None of the known verdicts matched — show line 10 verbatim for debugging
-            LINE10=$(sed -n '10p' "$OUTFILE")
-            VERDICT=$(echo "$LINE10" | sed 's/.*): //')
-            if [[ -n "$VERDICT" && "$VERDICT" != "$LINE10" ]]; then
-                # Pattern matched — unusual verdict string (e.g. WATCHLIST, SPECULATIVE_BUY)
+        VERDICT=$(extract_report_verdict "$OUTFILE")
+        case "$VERDICT" in
+            BUY)
+                echo "$ticker" >> "$BUY_LIST"
+                BUY_COUNT=$((BUY_COUNT + 1))
+                success "BUY: $ticker"
+                ;;
+            SELL)
+                SELL_COUNT=$((SELL_COUNT + 1))
+                info "SELL: $ticker"
+                ;;
+            HOLD)
+                HOLD_COUNT=$((HOLD_COUNT + 1))
+                info "HOLD: $ticker"
+                ;;
+            DO_NOT_INITIATE)
+                SELL_COUNT=$((SELL_COUNT + 1))
+                info "DO_NOT_INITIATE: $ticker"
+                ;;
+            "")
+                HEADER=$(report_verdict_line "$OUTFILE")
+                warn "UNKNOWN: $ticker [header: ${HEADER:-<empty>}]"
+                OTHER_COUNT=$((OTHER_COUNT + 1))
+                ;;
+            *)
                 warn "UNKNOWN_VERDICT ($VERDICT): $ticker"
-            else
-                # Pattern didn't match — title not on line 10 or unexpected format
-                warn "UNKNOWN: $ticker [line10: ${LINE10:-<empty>}]"
-            fi
-            OTHER_COUNT=$((OTHER_COUNT + 1))
-        fi
+                OTHER_COUNT=$((OTHER_COUNT + 1))
+                ;;
+        esac
 
     done < "$TICKER_LIST"
 
@@ -466,7 +504,7 @@ if [[ $START_STAGE -le 2 ]]; then
         [[ -z "$ticker" ]] && continue
         DASH=$(echo "$ticker" | tr '._' '-')
         OUTFILE="${SCRATCH}/README-${DASH}-${DATE}.md"
-        if $FORCE || ! [[ -f "$OUTFILE" ]] || ! grep -qE '^# .*\): ' "$OUTFILE"; then
+        if $FORCE || ! [[ -f "$OUTFILE" ]] || ! report_has_verdict_header "$OUTFILE"; then
             STAGE2_TODO=$((STAGE2_TODO + 1))
         fi
     done < "$BUY_LIST"
@@ -506,7 +544,7 @@ if [[ $START_STAGE -le 2 ]]; then
         LOGFILE="${SCRATCH}/${DASH}-LOG-${DATE}.txt"
 
         # Resumability: skip if full analysis output already has a verdict
-        if ! $FORCE && [[ -f "$OUTFILE" ]] && grep -qE '^# .*\): ' "$OUTFILE"; then
+        if ! $FORCE && [[ -f "$OUTFILE" ]] && report_has_verdict_header "$OUTFILE"; then
             STAGE2_SKIPPED=$((STAGE2_SKIPPED + 1))
             info "SKIP $ticker (full analysis exists)"
             continue
@@ -521,7 +559,7 @@ if [[ $START_STAGE -le 2 ]]; then
             $STRICT_FLAG \
             --output "$OUTFILE" \
             2> "$LOGFILE"; then
-            VERDICT=$(grep -m1 -E '^# .*\): ' "$OUTFILE" 2>/dev/null | sed 's/.*): //' | tr -d '\r')
+            VERDICT=$(extract_report_verdict "$OUTFILE")
             [[ -n "$VERDICT" ]] && success "$ticker done [Verdict=${VERDICT}]" || success "$ticker done"
         else
             fail "FAILED: $ticker (see $LOGFILE)"

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -43,6 +43,8 @@ AUTO_YES=false
 STRICT_FLAG=""
 RUN_DATE_OVERRIDE=""
 BUY_LIST_EXPLICIT=false
+PYTHON_CMD=()
+PYTHON_CMD_DISPLAY=""
 
 # --- Colors ---
 RED='\033[0;31m'
@@ -119,6 +121,30 @@ report_has_verdict_header() {
     local verdict
     verdict=$(extract_report_verdict "$file")
     [[ -n "$verdict" ]]
+}
+
+resolve_python_cmd() {
+    if [[ -n "${INVESTMENT_AGENT_CONTAINER:-}" ]] || [[ -f "/.dockerenv" ]] || [[ -f "/run/.containerenv" ]]; then
+        PYTHON_CMD=(python)
+        PYTHON_CMD_DISPLAY="python"
+        return
+    fi
+
+    if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+        PYTHON_CMD=(python)
+        PYTHON_CMD_DISPLAY="python"
+        return
+    fi
+
+    if command -v poetry &> /dev/null; then
+        PYTHON_CMD=(poetry run python)
+        PYTHON_CMD_DISPLAY="poetry run python"
+        return
+    fi
+
+    fail "Poetry is not installed and no active virtual environment was detected"
+    info "Either activate your venv, or install Poetry from: https://python-poetry.org/docs/#installation"
+    exit 1
 }
 
 extract_date_from_path() {
@@ -315,12 +341,9 @@ fi
 # --- Ensure scratch directory exists ---
 mkdir -p "$SCRATCH"
 
-# --- Check Poetry is available ---
-if ! command -v poetry &> /dev/null; then
-    fail "Poetry is not installed"
-    info "Install from: https://python-poetry.org/docs/#installation"
-    exit 1
-fi
+# --- Resolve Python runtime ---
+resolve_python_cmd
+info "Python runtime:      $PYTHON_CMD_DISPLAY"
 
 # ============================================================
 # STAGE 0: Scrape + Filter
@@ -339,13 +362,13 @@ if [[ $START_STAGE -le 0 ]]; then
         TICKER_LIST="$SKIP_SCRAPE"
         info "Using existing ticker list: $TICKER_LIST"
     else
-        GEMS_CMD="poetry run python scripts/find_gems.py --output $TICKER_LIST --details ${SCRATCH}/gems_details_${DATE}.csv"
+        GEMS_CMD=("${PYTHON_CMD[@]}" scripts/find_gems.py --output "$TICKER_LIST" --details "${SCRATCH}/gems_details_${DATE}.csv")
         if [[ -n "$INCLUDE_US" ]]; then
-            GEMS_CMD="$GEMS_CMD $INCLUDE_US"
+            GEMS_CMD+=("$INCLUDE_US")
         fi
 
-        info "Running: $GEMS_CMD"
-        if eval "$GEMS_CMD"; then
+        info "Running: ${GEMS_CMD[*]}"
+        if "${GEMS_CMD[@]}"; then
             success "Scrape + filter complete"
         else
             fail "find_gems.py failed"
@@ -475,7 +498,7 @@ if [[ $START_STAGE -le 1 ]]; then
         STAGE1_PROCESSED=$((STAGE1_PROCESSED + 1))
         info "[$STAGE1_PROCESSED/$STAGE1_TODO, $TICKER_COUNT total] Quick: $ticker"
 
-        if poetry run python -m src.main \
+        if "${PYTHON_CMD[@]}" -m src.main \
             --ticker "$ticker" \
             --quick --strict --no-charts --quiet --brief --no-memory \
             --output "$OUTFILE" \
@@ -643,7 +666,7 @@ if [[ $START_STAGE -le 2 ]]; then
         STAGE2_PROCESSED=$((STAGE2_PROCESSED + 1))
         info "[$STAGE2_PROCESSED/$STAGE2_TODO, $BUY_TOTAL total] Full: $ticker"
 
-        if poetry run python -m src.main \
+        if "${PYTHON_CMD[@]}" -m src.main \
             --ticker "$ticker" \
             --transparent --quiet \
             $STRICT_FLAG \

--- a/scripts/run_pipeline.sh
+++ b/scripts/run_pipeline.sh
@@ -13,6 +13,7 @@
 #   --include-us        Pass --include-us to find_gems.py
 #   --cooldown N        Override COOLDOWN_SECONDS (default: 60)
 #   --stage N           Start from stage N (0, 1, or 2). Requires prior stages' outputs.
+#   --run-date DATE     Force output/resume date (YYYY-MM-DD), useful for cross-day resume
 #   --buys-file FILE    Explicit BUY list path (bypasses date-based default; use with --stage 2
 #                       when resuming a run that started on a previous calendar day)
 #   -y, --yes           Skip confirmation prompts (run non-interactively)
@@ -40,6 +41,8 @@ INCLUDE_US=""
 START_STAGE=0
 AUTO_YES=false
 STRICT_FLAG=""
+RUN_DATE_OVERRIDE=""
+BUY_LIST_EXPLICIT=false
 
 # --- Colors ---
 RED='\033[0;31m'
@@ -88,7 +91,7 @@ report_verdict_line() {
         /^# / {
             line=$0
             sub(/\r$/, "", line)
-            if (match(line, /: [A-Z_]+$/)) {
+            if (match(line, /: .+$/)) {
                 found = 1
                 print line
                 exit 0
@@ -118,6 +121,74 @@ report_has_verdict_header() {
     [[ -n "$verdict" ]]
 }
 
+extract_date_from_path() {
+    local path="$1"
+    basename "$path" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1 || true
+}
+
+apply_run_date() {
+    local source_label="$1"
+    local new_date="$2"
+    if [[ -z "$new_date" || "$new_date" == "$DATE" ]]; then
+        return
+    fi
+
+    info "Cross-day resume: using date ${new_date} from ${source_label} (was ${DATE})"
+    DATE="$new_date"
+    if [[ -z "$SKIP_SCRAPE" ]]; then
+        TICKER_LIST="${SCRATCH}/gems_${DATE}.txt"
+    fi
+    if ! $BUY_LIST_EXPLICIT; then
+        BUY_LIST="${SCRATCH}/buys_${DATE}.txt"
+    fi
+}
+
+ticker_to_dash() {
+    local ticker="$1"
+    printf '%s\n' "$ticker" | tr '._' '-'
+}
+
+quick_outfile_for() {
+    local ticker="$1"
+    local run_date="$2"
+    local dash
+    dash=$(ticker_to_dash "$ticker")
+    printf '%s/README-%s-%s_quick.md\n' "$SCRATCH" "$dash" "$run_date"
+}
+
+count_completed_quick_reports_for_date() {
+    local ticker_list="$1"
+    local run_date="$2"
+    local count=0
+    local ticker outfile
+    while IFS= read -r ticker || [[ -n "$ticker" ]]; do
+        [[ -z "$ticker" || "$ticker" =~ ^[[:space:]]*# ]] && continue
+        ticker=$(echo "$ticker" | xargs)
+        [[ -z "$ticker" ]] && continue
+        outfile=$(quick_outfile_for "$ticker" "$run_date")
+        if [[ -f "$outfile" ]] && report_has_verdict_header "$outfile"; then
+            count=$((count + 1))
+        fi
+    done < "$ticker_list"
+    printf '%s\n' "$count"
+}
+
+detect_stage1_resume_date() {
+    local ticker_list="$1"
+    local inferred_date="$2"
+    local today_date="$3"
+    local inferred_count today_count
+
+    inferred_count=$(count_completed_quick_reports_for_date "$ticker_list" "$inferred_date")
+    today_count=$(count_completed_quick_reports_for_date "$ticker_list" "$today_date")
+
+    if [[ "$today_count" -gt "$inferred_count" ]]; then
+        printf '%s\n' "$today_date"
+    else
+        printf '%s\n' "$inferred_date"
+    fi
+}
+
 # --- Parse arguments ---
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -136,8 +207,12 @@ while [[ $# -gt 0 ]]; do
         --stage)
             START_STAGE="$2"
             shift 2 ;;
+        --run-date)
+            RUN_DATE_OVERRIDE="$2"
+            shift 2 ;;
         --buys-file)
             BUY_LIST="$2"
+            BUY_LIST_EXPLICIT=true
             shift 2 ;;
         -y|--yes)
             AUTO_YES=true
@@ -162,6 +237,7 @@ OPTIONS:
   --include-us        Include US exchanges in scrape phase
   --cooldown N        Seconds between ticker analyses (default: 60)
   --stage N           Start from stage N (0, 1, or 2)
+  --run-date DATE     Force the pipeline/output date (YYYY-MM-DD) for cross-day resume
   --buys-file FILE    Explicit BUY list path — bypasses the date-based default
                       (scratch/buys_YYYY-MM-DD.txt). Use with --stage 2 when
                       resuming a run that crossed midnight:
@@ -191,6 +267,12 @@ EXAMPLES:
   # Start from Stage 2 (BUY list must exist from prior run)
   ./scripts/run_pipeline.sh --stage 2
 
+  # Resume a prior Stage 1 run from its original date
+  ./scripts/run_pipeline.sh --stage 1 --skip-scrape scratch/gems_2026-02-24.txt
+
+  # Resume using an explicit run date when filenames were copied/renamed
+  ./scripts/run_pipeline.sh --stage 1 --skip-scrape scratch/gems_2026-02-25.txt --run-date 2026-02-24
+
   # Non-interactive (e.g. cron, CI, overnight run)
   caffeinate -i ./scripts/run_pipeline.sh --yes
 
@@ -211,14 +293,22 @@ if [[ -n "$SKIP_SCRAPE" ]]; then
     TICKER_LIST="$SKIP_SCRAPE"
 fi
 
-# If --buys-file was given, derive DATE from the filename so that Stage 2 output
-# filenames and resumability checks stay consistent with the original run.
-# e.g. scratch/buys_2026-03-02.txt  →  DATE=2026-03-02
-if [[ "$BUY_LIST" != "${SCRATCH}/buys_${DATE}.txt" ]]; then
-    EXTRACTED_DATE=$(basename "$BUY_LIST" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1)
-    if [[ -n "$EXTRACTED_DATE" ]]; then
-        info "Cross-day resume: using date ${EXTRACTED_DATE} from buys file (was ${DATE})"
-        DATE="$EXTRACTED_DATE"
+# Date precedence:
+# 1. explicit --run-date
+# 2. explicit --buys-file date
+# 3. --skip-scrape ticker-list date
+if [[ -n "$RUN_DATE_OVERRIDE" ]]; then
+    apply_run_date "run-date override" "$RUN_DATE_OVERRIDE"
+elif $BUY_LIST_EXPLICIT; then
+    apply_run_date "buys file" "$(extract_date_from_path "$BUY_LIST")"
+elif [[ -n "$SKIP_SCRAPE" ]]; then
+    apply_run_date "ticker list" "$(extract_date_from_path "$TICKER_LIST")"
+fi
+
+if [[ -n "$SKIP_SCRAPE" && -z "$RUN_DATE_OVERRIDE" && ! $BUY_LIST_EXPLICIT && $START_STAGE -eq 1 ]]; then
+    DETECTED_STAGE1_DATE=$(detect_stage1_resume_date "$TICKER_LIST" "$DATE" "$(date +%Y-%m-%d)")
+    if [[ -n "$DETECTED_STAGE1_DATE" && "$DETECTED_STAGE1_DATE" != "$DATE" ]]; then
+        apply_run_date "existing quick outputs" "$DETECTED_STAGE1_DATE"
     fi
 fi
 
@@ -449,7 +539,7 @@ if [[ $START_STAGE -le 1 ]]; then
                 HOLD_COUNT=$((HOLD_COUNT + 1))
                 info "HOLD: $ticker"
                 ;;
-            DO_NOT_INITIATE)
+            DO_NOT_INITIATE|DO\ NOT\ INITIATE)
                 SELL_COUNT=$((SELL_COUNT + 1))
                 info "DO_NOT_INITIATE: $ticker"
                 ;;

--- a/scripts/run_tickers.sh
+++ b/scripts/run_tickers.sh
@@ -178,6 +178,30 @@ print_success() {
     echo -e "${GREEN}[SUCCESS]${NC} $1"
 }
 
+resolve_python_cmd() {
+    if [[ -n "${INVESTMENT_AGENT_CONTAINER:-}" ]] || [[ -f "/.dockerenv" ]] || [[ -f "/run/.containerenv" ]]; then
+        PYTHON_CMD=(python)
+        PYTHON_CMD_DISPLAY="python"
+        return
+    fi
+
+    if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+        PYTHON_CMD=(python)
+        PYTHON_CMD_DISPLAY="python"
+        return
+    fi
+
+    if command -v poetry &> /dev/null; then
+        PYTHON_CMD=(poetry run python)
+        PYTHON_CMD_DISPLAY="poetry run python"
+        return
+    fi
+
+    print_error "Poetry is not installed and no active virtual environment was detected"
+    print_info "Either activate your venv, or install Poetry from: https://python-poetry.org/docs/#installation"
+    exit 1
+}
+
 # Ensure output directories exist
 mkdir -p "$(dirname "$OUTPUT_FILE")"
 mkdir -p "$IMAGE_DIR"
@@ -207,12 +231,7 @@ if [[ "$ticker_count" -eq 0 ]]; then
     exit 1
 fi
 
-# Check if Poetry is available
-if ! command -v poetry &> /dev/null; then
-    print_error "Poetry is not installed"
-    print_info "Install from: https://python-poetry.org/docs/#installation"
-    exit 1
-fi
+resolve_python_cmd
 
 # Initialize output file with header
 cat > "$OUTPUT_FILE" << EOF
@@ -255,6 +274,7 @@ print_info "Input: $INPUT_FILE ($ticker_count tickers)"
 print_info "Output: $OUTPUT_FILE"
 print_info "Logs:  $LOG_FILE"
 print_info "Images: $IMAGE_DIR"
+print_info "Python: $PYTHON_CMD_DISPLAY"
 echo ""
 
 # Process each ticker
@@ -285,29 +305,29 @@ while IFS= read -r line || [[ -n "$line" ]]; do
     TEMP_LOG="${OUTPUT_DIR}/.temp_analysis_${ticker}.log"
 
     # Build the Python command based on flags
-    PYTHON_CMD="poetry run python"
+    ticker_cmd=("${PYTHON_CMD[@]}")
 
     # Add -u flag for unbuffered output in loud mode
     if $LOUD_MODE; then
-        PYTHON_CMD="$PYTHON_CMD -u"
+        ticker_cmd+=(-u)
     fi
 
     # Use --output to ensure charts are generated correctly
-    PYTHON_CMD="$PYTHON_CMD -m src.main --ticker $ticker --imagedir $IMAGE_DIR --output $TEMP_REPORT"
+    ticker_cmd+=(-m src.main --ticker "$ticker" --imagedir "$IMAGE_DIR" --output "$TEMP_REPORT")
 
     # Add --quiet unless in loud mode
     if ! $LOUD_MODE; then
-        PYTHON_CMD="$PYTHON_CMD --quiet"
+        ticker_cmd+=(--quiet)
     fi
 
     # Add --brief unless in loud or verbose mode
     if ! $LOUD_MODE && ! $VERBOSE_MODE; then
-        PYTHON_CMD="$PYTHON_CMD --brief"
+        ticker_cmd+=(--brief)
     fi
 
     # Add --quick if in quick mode
     if $QUICK_MODE; then
-        PYTHON_CMD="$PYTHON_CMD --quick"
+        ticker_cmd+=(--quick)
     fi
 
     # Run analysis
@@ -320,12 +340,12 @@ while IFS= read -r line || [[ -n "$line" ]]; do
     if $LOUD_MODE; then
         # In loud mode: logs to terminal AND master log file
         # pipefail is set, so if python fails, this returns failure
-        if $PYTHON_CMD 2>&1 | tee -a "$LOG_FILE"; then
+        if "${ticker_cmd[@]}" 2>&1 | tee -a "$LOG_FILE"; then
             SUCCESS=true
         fi
     else
         # In quiet mode: logs capture to temp log
-        if $PYTHON_CMD > "$TEMP_LOG" 2>&1; then
+        if "${ticker_cmd[@]}" > "$TEMP_LOG" 2>&1; then
             SUCCESS=true
         fi
 
@@ -343,7 +363,7 @@ while IFS= read -r line || [[ -n "$line" ]]; do
             failed=$((failed + 1))
 
             # Treat as failure for debugging purposes
-            local debug_dir="${OUTPUT_DIR}/debug_failures"
+            debug_dir="${OUTPUT_DIR}/debug_failures"
             mkdir -p "$debug_dir"
             cp "$TEMP_REPORT" "$debug_dir/${ticker}_report.md" 2>/dev/null || true
             if ! $LOUD_MODE && [ -f "$TEMP_LOG" ]; then

--- a/scripts/setup-github-secrets.sh
+++ b/scripts/setup-github-secrets.sh
@@ -47,7 +47,7 @@ Usage: ./scripts/setup-github-secrets.sh --repo owner/repo [OPTIONS]
 Upload API keys from .env to GitHub as encrypted secrets.
 
 REQUIRED:
-    --repo OWNER/REPO    GitHub repository (e.g., "username/trading-system")
+    --repo OWNER/REPO    GitHub repository (e.g., "username/investment-agent")
 
 OPTIONAL:
     --env-file FILE      Path to .env file (default: .env)
@@ -57,7 +57,7 @@ OPTIONAL:
 
 EXAMPLES:
     # Upload secrets to your repository
-    ./scripts/setup-github-secrets.sh --repo myusername/my-trading-system
+    ./scripts/setup-github-secrets.sh --repo myusername/investment-agent
 
     # Dry run to see what would happen
     ./scripts/setup-github-secrets.sh --repo myusername/my-repo --dry-run

--- a/scripts/terraform-ops.sh
+++ b/scripts/terraform-ops.sh
@@ -14,7 +14,8 @@
 #   ✓ Have tested in a dev environment first
 #
 # IF YOU JUST WANT TO ANALYZE STOCKS LOCALLY:
-#   DO NOT USE THIS SCRIPT - use ./scripts/run-analysis.sh instead
+#   DO NOT USE THIS SCRIPT - run `python -m src.main --ticker 0005.HK`
+#   (or `poetry run python -m src.main ...` in manual repo mode) instead
 #
 # COMMANDS:
 #   validate  - Check Terraform configuration (safe, no changes)

--- a/src/agents/analyst_nodes.py
+++ b/src/agents/analyst_nodes.py
@@ -21,6 +21,11 @@ from src.runtime_diagnostics import failure_artifact, success_artifact
 
 from . import message_utils, support
 from . import runtime as agent_runtime
+from .output_validation import (
+    log_output_diagnostics,
+    should_fail_closed,
+    validate_required_output,
+)
 from .state import AgentState
 
 logger = structlog.get_logger(__name__)
@@ -390,6 +395,7 @@ def create_analyst_node(
                         retry_improved=len(retry_content_str) > len(content_str),
                     )
                     content_str = retry_content_str
+                    response = retry_response
                 except Exception as retry_error:
                     logger.error(
                         "analyst_retry_failed",
@@ -397,6 +403,51 @@ def create_analyst_node(
                         ticker=ticker,
                         error=str(retry_error),
                     )
+
+            from src.utils import detect_truncation
+
+            trunc_info = detect_truncation(content_str, agent=agent_key)
+            if trunc_info["truncated"]:
+                logger.warning(
+                    "agent_output_truncated",
+                    agent=agent_key,
+                    ticker=ticker,
+                    source=trunc_info["source"],
+                    marker=trunc_info["marker"],
+                    confidence=trunc_info["confidence"],
+                    output_len=len(content_str),
+                )
+
+            validation = validate_required_output(agent_key, content_str)
+            log_output_diagnostics(
+                agent_key=agent_key,
+                ticker=ticker,
+                runnable=llm if response is not None else llm,
+                response=response,
+                content=content_str,
+                truncated=trunc_info["truncated"],
+                validation=validation if validation["checks"] else None,
+            )
+            if should_fail_closed(
+                agent_key,
+                validation=validation,
+                truncated=trunc_info["truncated"],
+                content=content_str,
+            ):
+                logger.error(
+                    "analyst_invalid_structure",
+                    agent=agent_key,
+                    ticker=ticker,
+                    missing_sections=validation["missing"],
+                )
+                result = failure_artifact(
+                    output_field,
+                    f"{agent_key} output missing required structure",
+                    provider=support.infer_provider_name(llm),
+                    fallback_content=content_str,
+                )
+                new_state.update(result)
+                return new_state
 
             new_state.update(
                 success_artifact(

--- a/src/agents/consultant_nodes.py
+++ b/src/agents/consultant_nodes.py
@@ -17,6 +17,11 @@ from src.tooling.runtime import TOOL_SERVICE, ToolInvocation
 
 from . import message_utils, support
 from . import runtime as agent_runtime
+from .output_validation import (
+    log_output_diagnostics,
+    should_fail_closed,
+    validate_required_output,
+)
 from .state import AgentState
 
 logger = structlog.get_logger(__name__)
@@ -390,6 +395,34 @@ Provide your independent consultant review."""
                     marker=trunc_info["marker"],
                     confidence=trunc_info["confidence"],
                     output_len=len(content_str),
+                )
+
+            validation = validate_required_output("consultant", content_str)
+            log_output_diagnostics(
+                agent_key="consultant",
+                ticker=ticker,
+                runnable=llm,
+                response=response,
+                content=content_str,
+                truncated=trunc_info["truncated"],
+                validation=validation,
+            )
+            if should_fail_closed(
+                "consultant",
+                validation=validation,
+                truncated=trunc_info["truncated"],
+                content=content_str,
+            ):
+                logger.error(
+                    "consultant_invalid_structure",
+                    ticker=ticker,
+                    missing_sections=validation["missing"],
+                )
+                return failure_artifact(
+                    "consultant_review",
+                    "Consultant output missing required structure",
+                    provider=support.infer_provider_name(llm),
+                    fallback_content=content_str,
                 )
 
             logger.info(
@@ -767,6 +800,53 @@ Perform a forensic audit using your tools."""
 
         try:
             response_str = await _run_auditor_loop(llm, agent_prompt.system_message)
+
+            from src.utils import detect_truncation
+
+            trunc_info = detect_truncation(
+                response_str, agent="global_forensic_auditor"
+            )
+            if trunc_info["truncated"]:
+                logger.warning(
+                    "agent_output_truncated",
+                    agent="global_forensic_auditor",
+                    ticker=ticker,
+                    source=trunc_info["source"],
+                    marker=trunc_info["marker"],
+                    confidence=trunc_info["confidence"],
+                    output_len=len(response_str),
+                )
+            validation = validate_required_output(
+                "global_forensic_auditor", response_str
+            )
+            log_output_diagnostics(
+                agent_key="global_forensic_auditor",
+                ticker=ticker,
+                runnable=llm,
+                response=None,
+                content=response_str,
+                truncated=trunc_info["truncated"],
+                validation=validation,
+            )
+            if should_fail_closed(
+                "global_forensic_auditor",
+                validation=validation,
+                truncated=trunc_info["truncated"],
+                content=response_str,
+            ):
+                logger.error(
+                    "auditor_invalid_structure",
+                    ticker=ticker,
+                    missing_sections=validation["missing"],
+                )
+                result = failure_artifact(
+                    "auditor_report",
+                    "Auditor output missing required structure",
+                    provider=support.infer_provider_name(llm),
+                    fallback_content=response_str,
+                )
+                result["sender"] = "global_forensic_auditor"
+                return result
 
             logger.info("auditor_complete", ticker=ticker, length=len(response_str))
             result = success_artifact(

--- a/src/agents/consultant_nodes.py
+++ b/src/agents/consultant_nodes.py
@@ -10,7 +10,6 @@ from datetime import datetime
 import structlog
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.messages import ToolMessage as TM
-from langgraph.prebuilt import create_react_agent
 from langgraph.types import RunnableConfig
 
 from src.runtime_diagnostics import ArtifactStatus, failure_artifact, success_artifact
@@ -83,6 +82,23 @@ async def _invoke_consultant_with_deadline(
         raise TimeoutError(
             f"Consultant call exceeded {timeout_s:.1f}s wall-clock timeout for {ticker}"
         ) from exc
+
+
+async def _invoke_agent_loop_llm(
+    runnable,
+    messages,
+    *,
+    context: str,
+) -> object:
+    """Invoke an agent-loop LLM through the shared retry-aware runtime helper."""
+    model_name = getattr(runnable, "model_name", None)
+    return await agent_runtime.invoke_with_rate_limit_handling(
+        runnable,
+        messages,
+        context=context,
+        provider=support.infer_provider_name(runnable),
+        model_name=model_name,
+    )
 
 
 def _build_legal_fallback_report(
@@ -465,19 +481,68 @@ Date: {support._format_date_with_fy_hint(current_date)}
 
 Call the search_legal_tax_disclosures tool with these parameters, then provide your JSON assessment."""
 
-        try:
-            agent = create_react_agent(llm, tools)
-            result = await agent.ainvoke(
-                {
-                    "messages": [
-                        SystemMessage(content=agent_prompt.system_message),
-                        HumanMessage(content=human_msg),
-                    ]
-                }
-            )
+        tools_by_name = {t.name: t for t in tools}
+        max_tool_iterations = 4
 
-            response = result["messages"][-1].content
-            response_str = message_utils.extract_string_content(response)
+        try:
+            messages: list = [
+                SystemMessage(content=agent_prompt.system_message),
+                HumanMessage(content=human_msg),
+            ]
+            response_str = ""
+
+            for iteration in range(max_tool_iterations + 1):
+                response = await _invoke_agent_loop_llm(
+                    llm,
+                    messages,
+                    context="legal_counsel",
+                )
+                tool_calls = getattr(response, "tool_calls", None)
+
+                if (
+                    not isinstance(tool_calls, list)
+                    or not tool_calls
+                    or iteration == max_tool_iterations
+                ):
+                    response_str = message_utils.extract_string_content(
+                        response.content
+                    )
+                    break
+
+                messages.append(response)
+                for tool_call in tool_calls:
+                    tool_fn = tools_by_name.get(tool_call["name"])
+                    tool_call_id = tool_call.get("id", tool_call["name"])
+                    if tool_fn:
+                        try:
+                            tool_result = await TOOL_SERVICE.execute(
+                                ToolInvocation(
+                                    name=tool_call["name"],
+                                    args=tool_call["args"],
+                                    source="legal_counsel",
+                                    agent_key="legal_counsel",
+                                ),
+                                runner=lambda args, fn=tool_fn: fn.ainvoke(args),
+                            )
+                            tool_output = str(tool_result.value)
+                        except Exception as tool_err:
+                            logger.warning(
+                                "legal_counsel_tool_failed",
+                                ticker=ticker,
+                                tool=tool_call["name"],
+                                error=str(tool_err),
+                            )
+                            tool_output = f"TOOL_ERROR: {tool_err}"
+                    else:
+                        tool_output = f"Unknown tool: {tool_call['name']}"
+                    messages.append(TM(content=tool_output, tool_call_id=tool_call_id))
+
+                logger.info(
+                    "legal_counsel_tool_iteration",
+                    ticker=ticker,
+                    iteration=iteration + 1,
+                    tools_called=[tc["name"] for tc in tool_calls],
+                )
 
             try:
                 parsed = json.loads(response_str)
@@ -563,47 +628,6 @@ def create_auditor_node(llm, tools: list) -> Callable:
     """
     max_tool_output_chars = 63500
 
-    def truncate_tool_outputs_hook(state: dict) -> dict:
-        from langchain_core.messages import ToolMessage
-
-        messages = state.get("messages", [])
-        modified = []
-        for message in messages:
-            if isinstance(message, ToolMessage):
-                content = (
-                    message.content
-                    if isinstance(message.content, str)
-                    else str(message.content)
-                )
-                if len(content) > max_tool_output_chars:
-                    head_size = 58000
-                    tail_size = 5500
-                    truncated_chars = len(content) - head_size - tail_size
-                    truncated = (
-                        content[:head_size]
-                        + f"\n\n[...TRUNCATED {truncated_chars:,} chars...]\n"
-                        + "[NOTE: Data truncated due to size limits. Partial analysis may still be useful. "
-                        + "Key financial metrics may appear in head or tail sections above/below.]\n\n"
-                        + content[-tail_size:]
-                    )
-                    modified.append(
-                        ToolMessage(
-                            content=truncated,
-                            tool_call_id=message.tool_call_id,
-                            name=getattr(message, "name", None),
-                        )
-                    )
-                    logger.debug(
-                        "auditor_tool_output_truncated",
-                        original_len=len(content),
-                        truncated_len=len(truncated),
-                    )
-                else:
-                    modified.append(message)
-            else:
-                modified.append(message)
-        return {"llm_input_messages": modified}
-
     async def auditor_node(state: AgentState, config: RunnableConfig) -> dict[str, str]:
         from src.prompts import get_prompt
 
@@ -635,26 +659,114 @@ Date: {support._format_date_with_fy_hint(current_date)}
 
 Perform a forensic audit using your tools."""
 
+        tools_by_name = {t.name: t for t in tools}
+        # recursion_limit=12 in the old create_react_agent maps to 6 tool-call rounds
+        # (each round = 1 LLM call + 1 tool execution step in LangGraph).
+        # We use 6 manual iterations here to preserve the same budget.
+        max_tool_iterations = 6
+
+        def _truncate_messages_for_llm(msgs: list) -> list:
+            """Apply the auditor truncation hook to ToolMessages before LLM invocation."""
+            from langchain_core.messages import ToolMessage as LCToolMessage
+
+            result_msgs = []
+            for msg in msgs:
+                if isinstance(msg, LCToolMessage):
+                    content = (
+                        msg.content
+                        if isinstance(msg.content, str)
+                        else str(msg.content)
+                    )
+                    if len(content) > max_tool_output_chars:
+                        head_size = 58000
+                        tail_size = 5500
+                        truncated_chars = len(content) - head_size - tail_size
+                        truncated = (
+                            content[:head_size]
+                            + f"\n\n[...TRUNCATED {truncated_chars:,} chars...]\n"
+                            + "[NOTE: Data truncated due to size limits. Partial analysis may still be useful. "
+                            + "Key financial metrics may appear in head or tail sections above/below.]\n\n"
+                            + content[-tail_size:]
+                        )
+                        result_msgs.append(
+                            LCToolMessage(
+                                content=truncated,
+                                tool_call_id=msg.tool_call_id,
+                                name=getattr(msg, "name", None),
+                            )
+                        )
+                        logger.debug(
+                            "auditor_tool_output_truncated",
+                            original_len=len(content),
+                            truncated_len=len(truncated),
+                        )
+                    else:
+                        result_msgs.append(msg)
+                else:
+                    result_msgs.append(msg)
+            return result_msgs
+
+        async def _run_auditor_loop(active_llm, agent_prompt_sys: str) -> str:
+            messages: list = [
+                SystemMessage(content=agent_prompt_sys),
+                HumanMessage(content=human_msg),
+            ]
+            for iteration in range(max_tool_iterations + 1):
+                llm_input = _truncate_messages_for_llm(messages)
+                response = await _invoke_agent_loop_llm(
+                    active_llm,
+                    llm_input,
+                    context="global_forensic_auditor",
+                )
+                tool_calls = getattr(response, "tool_calls", None)
+
+                if (
+                    not isinstance(tool_calls, list)
+                    or not tool_calls
+                    or iteration == max_tool_iterations
+                ):
+                    return message_utils.extract_string_content(response.content)
+
+                messages.append(response)
+                for tool_call in tool_calls:
+                    tool_fn = tools_by_name.get(tool_call["name"])
+                    tool_call_id = tool_call.get("id", tool_call["name"])
+                    if tool_fn:
+                        try:
+                            tool_result = await TOOL_SERVICE.execute(
+                                ToolInvocation(
+                                    name=tool_call["name"],
+                                    args=tool_call["args"],
+                                    source="auditor",
+                                    agent_key="global_forensic_auditor",
+                                ),
+                                runner=lambda args, fn=tool_fn: fn.ainvoke(args),
+                            )
+                            tool_output = str(tool_result.value)
+                        except Exception as tool_err:
+                            logger.warning(
+                                "auditor_tool_failed",
+                                ticker=ticker,
+                                tool=tool_call["name"],
+                                error=str(tool_err),
+                            )
+                            tool_output = f"TOOL_ERROR: {tool_err}"
+                    else:
+                        tool_output = f"Unknown tool: {tool_call['name']}"
+                    messages.append(TM(content=tool_output, tool_call_id=tool_call_id))
+
+                logger.info(
+                    "auditor_tool_iteration",
+                    ticker=ticker,
+                    iteration=iteration + 1,
+                    tools_called=[tc["name"] for tc in tool_calls],
+                )
+            return ""
+
         logger.info("auditor_start", ticker=ticker)
 
         try:
-            agent = create_react_agent(
-                llm,
-                tools,
-                pre_model_hook=truncate_tool_outputs_hook,
-            )
-            result = await agent.ainvoke(
-                {
-                    "messages": [
-                        SystemMessage(content=agent_prompt.system_message),
-                        HumanMessage(content=human_msg),
-                    ]
-                },
-                config={"recursion_limit": 12},
-            )
-
-            response = result["messages"][-1].content
-            response_str = message_utils.extract_string_content(response)
+            response_str = await _run_auditor_loop(llm, agent_prompt.system_message)
 
             logger.info("auditor_complete", ticker=ticker, length=len(response_str))
             result = success_artifact(
@@ -727,22 +839,9 @@ VERDICT: Rely on DATA_BLOCK metrics for {ticker}.
                         use_responses_api=True,
                         output_version="responses/v1",
                     )
-                    agent = create_react_agent(
-                        fallback_llm,
-                        tools,
-                        pre_model_hook=truncate_tool_outputs_hook,
+                    response_str = await _run_auditor_loop(
+                        fallback_llm, agent_prompt.system_message
                     )
-                    result = await agent.ainvoke(
-                        {
-                            "messages": [
-                                SystemMessage(content=agent_prompt.system_message),
-                                HumanMessage(content=human_msg),
-                            ]
-                        },
-                        config={"recursion_limit": 12},
-                    )
-                    response = result["messages"][-1].content
-                    response_str = message_utils.extract_string_content(response)
                     logger.info(
                         "auditor_complete_after_retry",
                         ticker=ticker,

--- a/src/agents/decision_nodes.py
+++ b/src/agents/decision_nodes.py
@@ -18,6 +18,11 @@ from src.runtime_diagnostics import (
 
 from . import message_utils, support
 from . import runtime as agent_runtime
+from .output_validation import (
+    log_output_diagnostics,
+    should_fail_closed,
+    validate_required_output,
+)
 from .state import AgentState
 
 logger = structlog.get_logger(__name__)
@@ -187,27 +192,32 @@ def create_trader_node(llm, memory: Any | None) -> Callable:
         consultant = get_valid_artifact_content(state, "consultant_review")
         consultant_section = (
             "\n\nEXTERNAL CONSULTANT REVIEW (Cross-Validation):\n"
-            f"{consultant if consultant else 'N/A (consultant disabled or unavailable)'}"
+            f"{support.summarize_for_pm(consultant, 'consultant', 2500) if consultant else 'N/A (consultant disabled or unavailable)'}"
         )
         valuation = state.get("valuation_params", "")
         valuation_section = (
             f"\n\nVALUATION PARAMETERS:\n{valuation}" if valuation else ""
         )
 
+        market_report = state.get("market_report", "N/A")
+        sentiment_report = state.get("sentiment_report", "N/A")
+        news_report = state.get("news_report", "N/A")
+        fundamentals_report = state.get("fundamentals_report", "N/A")
+        investment_plan = state.get("investment_plan", "N/A")
         all_input = f"""MARKET ANALYST REPORT:
-{state.get("market_report", "N/A")}
+{support.summarize_for_pm(market_report, "market", 1800) if market_report != "N/A" else "N/A"}
 
 SENTIMENT ANALYST REPORT:
-{state.get("sentiment_report", "N/A")}
+{support.summarize_for_pm(sentiment_report, "sentiment", 1200) if sentiment_report != "N/A" else "N/A"}
 
 NEWS ANALYST REPORT:
-{state.get("news_report", "N/A")}
+{support.summarize_for_pm(news_report, "news", 1800) if news_report != "N/A" else "N/A"}
 
 FUNDAMENTALS ANALYST REPORT:
-{state.get("fundamentals_report", "N/A")}
+{support.summarize_for_pm(fundamentals_report, "fundamentals", 6000) if fundamentals_report != "N/A" else "N/A"}
 
 RESEARCH MANAGER PLAN:
-{state.get("investment_plan", "N/A")}{consultant_section}{valuation_section}"""
+{support.summarize_for_pm(investment_plan, "research", 3500) if investment_plan != "N/A" else "N/A"}{consultant_section}{valuation_section}"""
         prompt = f"{agent_prompt.system_message}\n\n{all_input}\n\nCreate Trading Plan."
 
         try:
@@ -218,9 +228,32 @@ RESEARCH MANAGER PLAN:
                 provider=support.infer_provider_name(llm),
                 model_name=support.get_model_name(llm),
             )
+            content_str = message_utils.extract_string_content(response.content)
+            from src.utils import detect_truncation
+
+            trunc_info = detect_truncation(content_str, agent="trader")
+            if trunc_info["truncated"]:
+                logger.warning(
+                    "agent_output_truncated",
+                    agent="trader",
+                    ticker=state.get("company_of_interest", "UNKNOWN"),
+                    source=trunc_info["source"],
+                    marker=trunc_info["marker"],
+                    confidence=trunc_info["confidence"],
+                    output_len=len(content_str),
+                )
+            log_output_diagnostics(
+                agent_key="trader",
+                ticker=state.get("company_of_interest", "UNKNOWN"),
+                runnable=llm,
+                response=response,
+                content=content_str,
+                truncated=trunc_info["truncated"],
+                validation=None,
+            )
             return success_artifact(
                 "trader_investment_plan",
-                message_utils.extract_string_content(response.content),
+                content_str,
                 provider=support.infer_provider_name(llm),
             )
         except Exception as exc:
@@ -509,6 +542,34 @@ RISK TEAM DEBATE:
                     marker=trunc_info["marker"],
                     confidence=trunc_info["confidence"],
                     output_len=len(content_str),
+                )
+
+            validation = validate_required_output("portfolio_manager", content_str)
+            log_output_diagnostics(
+                agent_key="portfolio_manager",
+                ticker=ticker,
+                runnable=llm,
+                response=response,
+                content=content_str,
+                truncated=trunc_info["truncated"],
+                validation=validation,
+            )
+            if should_fail_closed(
+                "portfolio_manager",
+                validation=validation,
+                truncated=trunc_info["truncated"],
+                content=content_str,
+            ):
+                logger.error(
+                    "portfolio_manager_invalid_structure",
+                    ticker=ticker,
+                    missing_sections=validation["missing"],
+                )
+                return failure_artifact(
+                    "final_trade_decision",
+                    "Portfolio Manager output missing required structure",
+                    provider=support.infer_provider_name(llm),
+                    fallback_content=content_str,
                 )
 
             return success_artifact(

--- a/src/agents/output_validation.py
+++ b/src/agents/output_validation.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import re
+from numbers import Real
+from typing import Any
+
+import structlog
+
+from src.data_block_utils import has_parseable_data_block
+
+logger = structlog.get_logger(__name__)
+
+
+def _coerce_optional_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, Real):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def extract_completion_tokens(response: Any) -> int:
+    if response is None:
+        return 0
+
+    usage_metadata = getattr(response, "usage_metadata", None)
+    candidates: list[Any] = []
+
+    if isinstance(usage_metadata, dict):
+        candidates.extend(
+            [
+                usage_metadata.get("output_tokens"),
+                usage_metadata.get("completion_tokens"),
+                usage_metadata.get("total_output_tokens"),
+            ]
+        )
+    elif usage_metadata is not None and not callable(usage_metadata):
+        candidates.extend(
+            [
+                getattr(usage_metadata, "output_tokens", None),
+                getattr(usage_metadata, "completion_tokens", None),
+                getattr(usage_metadata, "total_output_tokens", None),
+            ]
+        )
+
+    response_metadata = getattr(response, "response_metadata", None)
+    if isinstance(response_metadata, dict):
+        token_usage = response_metadata.get("token_usage")
+        if isinstance(token_usage, dict):
+            candidates.extend(
+                [
+                    token_usage.get("completion_tokens"),
+                    token_usage.get("output_tokens"),
+                ]
+            )
+
+    for candidate in candidates:
+        coerced = _coerce_optional_int(candidate)
+        if coerced is not None:
+            return coerced
+
+    return 0
+
+
+def get_configured_output_cap(runnable: Any) -> int | None:
+    for attr in (
+        "_configured_max_output_tokens",
+        "_configured_max_completion_tokens",
+    ):
+        coerced = _coerce_optional_int(getattr(runnable, attr, None))
+        if coerced is not None:
+            return coerced
+    return None
+
+
+def validate_required_output(agent_key: str, content: str) -> dict[str, Any]:
+    checks: list[tuple[str, bool]] = []
+
+    if agent_key == "fundamentals_analyst":
+        checks.append(("parseable_data_block", has_parseable_data_block(content)))
+    elif agent_key == "portfolio_manager":
+        checks.extend(
+            [
+                ("verdict_header", "PORTFOLIO MANAGER VERDICT" in content),
+                (
+                    "thesis_summary",
+                    "THESIS COMPLIANCE SUMMARY" in content
+                    or "Hard Fail Checks:" in content,
+                ),
+                (
+                    "execution_section",
+                    "FINAL EXECUTION PARAMETERS" in content
+                    or "Recommended Position Size" in content
+                    or "PM_BLOCK" in content,
+                ),
+            ]
+        )
+    elif agent_key == "research_manager":
+        checks.extend(
+            [
+                (
+                    "recommendation",
+                    bool(
+                        re.search(
+                            r"(?:INVESTMENT|FINAL)\s+RECOMMENDATION\s*:",
+                            content,
+                            re.IGNORECASE,
+                        )
+                    ),
+                ),
+                (
+                    "supporting_section",
+                    "THESIS COMPLIANCE" in content or "RISKS TO MONITOR" in content,
+                ),
+            ]
+        )
+    elif agent_key == "consultant":
+        checks.extend(
+            [
+                ("review_header", "CONSULTANT REVIEW" in content),
+                ("final_verdict", "FINAL CONSULTANT VERDICT" in content),
+            ]
+        )
+    elif agent_key == "global_forensic_auditor":
+        checks.extend(
+            [
+                ("nonempty", bool(content.strip())),
+                (
+                    "forensic_summary",
+                    "FORENSIC_DATA_BLOCK" in content
+                    or "The Red Flags" in content
+                    or "STATUS:" in content
+                    or "VERDICT:" in content,
+                ),
+            ]
+        )
+
+    missing = [name for name, ok in checks if not ok]
+    return {"ok": not missing, "checks": checks, "missing": missing}
+
+
+def should_fail_closed(
+    agent_key: str,
+    *,
+    validation: dict[str, Any],
+    truncated: bool,
+    content: str,
+) -> bool:
+    if validation["ok"]:
+        return False
+
+    if agent_key in {"portfolio_manager", "fundamentals_analyst"}:
+        return True
+
+    if agent_key in {"consultant", "global_forensic_auditor"}:
+        return truncated and len(content.strip()) >= 200
+
+    return truncated or len(content.strip()) < 200
+
+
+def log_output_diagnostics(
+    *,
+    agent_key: str,
+    ticker: str,
+    runnable: Any,
+    response: Any,
+    content: str,
+    truncated: bool,
+    validation: dict[str, Any] | None,
+) -> None:
+    configured_cap = get_configured_output_cap(runnable)
+    completion_tokens = extract_completion_tokens(response)
+    utilization = (
+        round(completion_tokens / configured_cap, 4)
+        if configured_cap and completion_tokens
+        else None
+    )
+
+    logger.info(
+        "agent_output_diagnostics",
+        agent=agent_key,
+        ticker=ticker,
+        configured_output_cap=configured_cap,
+        completion_tokens=completion_tokens,
+        utilization_ratio=utilization,
+        truncated=truncated,
+        required_structure_ok=validation["ok"] if validation is not None else None,
+        missing_sections=validation["missing"] if validation is not None else [],
+        output_len=len(content),
+    )

--- a/src/agents/research_nodes.py
+++ b/src/agents/research_nodes.py
@@ -11,6 +11,11 @@ from src.runtime_diagnostics import failure_artifact, success_artifact
 
 from . import message_utils, support
 from . import runtime as agent_runtime
+from .output_validation import (
+    log_output_diagnostics,
+    should_fail_closed,
+    validate_required_output,
+)
 from .state import AgentState
 
 logger = structlog.get_logger(__name__)
@@ -66,17 +71,21 @@ def create_researcher_node(
                 }
             }
 
+        market_report = state.get("market_report", "N/A")
+        sentiment_report = state.get("sentiment_report", "N/A")
+        news_report = state.get("news_report", "N/A")
+        fundamentals_report = state.get("fundamentals_report", "N/A")
         reports = f"""MARKET ANALYST REPORT:
-{state.get("market_report", "N/A")}
+{support.summarize_for_pm(market_report, "market", 1800) if market_report != "N/A" else "N/A"}
 
 SENTIMENT ANALYST REPORT:
-{state.get("sentiment_report", "N/A")}
+{support.summarize_for_pm(sentiment_report, "sentiment", 1200) if sentiment_report != "N/A" else "N/A"}
 
 NEWS ANALYST REPORT:
-{state.get("news_report", "N/A")}
+{support.summarize_for_pm(news_report, "news", 1800) if news_report != "N/A" else "N/A"}
 
 FUNDAMENTALS ANALYST REPORT:
-{state.get("fundamentals_report", "N/A")}"""
+{support.summarize_for_pm(fundamentals_report, "fundamentals", 5500) if fundamentals_report != "N/A" else "N/A"}"""
 
         debate_state = state.get("investment_debate_state", {})
         if round_num == 1:
@@ -178,6 +187,28 @@ Only use data explicitly related to {ticker} ({company_name}).
                 model_name=support.get_model_name(llm),
             )
             content_str = message_utils.extract_string_content(response.content)
+            from src.utils import detect_truncation
+
+            trunc_info = detect_truncation(content_str, agent=agent_key)
+            if trunc_info["truncated"]:
+                logger.warning(
+                    "agent_output_truncated",
+                    agent=agent_key,
+                    ticker=ticker,
+                    source=trunc_info["source"],
+                    marker=trunc_info["marker"],
+                    confidence=trunc_info["confidence"],
+                    output_len=len(content_str),
+                )
+            log_output_diagnostics(
+                agent_key=agent_key,
+                ticker=ticker,
+                runnable=llm,
+                response=response,
+                content=content_str,
+                truncated=trunc_info["truncated"],
+                validation=None,
+            )
             argument = f"{agent_prompt.agent_name} (Round {round_num}): {content_str}"
             field_name = f"{researcher_type}_round{round_num}"
 
@@ -236,7 +267,13 @@ def create_research_manager_node(
                 "When Bull/Bear cite conflicting figures, check if they reference different time periods."
             )
 
-        all_reports = f"""MARKET ANALYST REPORT:\n{state.get("market_report", "N/A")}\n\nSENTIMENT ANALYST REPORT:\n{state.get("sentiment_report", "N/A")}\n\nNEWS ANALYST REPORT:\n{state.get("news_report", "N/A")}\n\nFUNDAMENTALS ANALYST REPORT:\n{state.get("fundamentals_report", "N/A")}{attribution_note}\n\nVALUE TRAP ANALYSIS:\n{value_trap}\n\nBULL RESEARCHER:\n{debate.get("bull_history", "N/A")}\n\nBEAR RESEARCHER:\n{debate.get("bear_history", "N/A")}"""
+        market_report = state.get("market_report", "N/A")
+        sentiment_report = state.get("sentiment_report", "N/A")
+        news_report = state.get("news_report", "N/A")
+        fundamentals_report = state.get("fundamentals_report", "N/A")
+        bull_history = debate.get("bull_history", "N/A")
+        bear_history = debate.get("bear_history", "N/A")
+        all_reports = f"""MARKET ANALYST REPORT:\n{support.summarize_for_pm(market_report, "market", 1800) if market_report != "N/A" else "N/A"}\n\nSENTIMENT ANALYST REPORT:\n{support.summarize_for_pm(sentiment_report, "sentiment", 1200) if sentiment_report != "N/A" else "N/A"}\n\nNEWS ANALYST REPORT:\n{support.summarize_for_pm(news_report, "news", 1800) if news_report != "N/A" else "N/A"}\n\nFUNDAMENTALS ANALYST REPORT:\n{support.summarize_for_pm(fundamentals_report, "fundamentals", 6000) if fundamentals_report != "N/A" else "N/A"}{attribution_note}\n\nVALUE TRAP ANALYSIS:\n{support.summarize_for_pm(value_trap, "value_trap", 2200) if value_trap != "N/A" else "N/A"}\n\nBULL RESEARCHER:\n{support.summarize_for_pm(bull_history, "research", 2500) if bull_history != "N/A" else "N/A"}\n\nBEAR RESEARCHER:\n{support.summarize_for_pm(bear_history, "research", 2500) if bear_history != "N/A" else "N/A"}"""
         system_msg = agent_prompt.system_message
         if strict_mode:
             system_msg += _STRICT_RM_ADDENDUM
@@ -264,6 +301,34 @@ def create_research_manager_node(
                     marker=trunc_info["marker"],
                     confidence=trunc_info["confidence"],
                     output_len=len(content_str),
+                )
+
+            validation = validate_required_output("research_manager", content_str)
+            log_output_diagnostics(
+                agent_key="research_manager",
+                ticker=state.get("company_of_interest", "UNKNOWN"),
+                runnable=llm,
+                response=response,
+                content=content_str,
+                truncated=trunc_info["truncated"],
+                validation=validation,
+            )
+            if should_fail_closed(
+                "research_manager",
+                validation=validation,
+                truncated=trunc_info["truncated"],
+                content=content_str,
+            ):
+                logger.error(
+                    "research_manager_invalid_structure",
+                    ticker=state.get("company_of_interest", "UNKNOWN"),
+                    missing_sections=validation["missing"],
+                )
+                return failure_artifact(
+                    "investment_plan",
+                    "Research Manager output missing required structure",
+                    provider=support.infer_provider_name(llm),
+                    fallback_content=content_str,
                 )
 
             return success_artifact(

--- a/src/config.py
+++ b/src/config.py
@@ -16,6 +16,7 @@ import logging
 import os
 import sys
 from pathlib import Path
+from typing import Literal
 
 import structlog
 from pydantic import Field, SecretStr, model_validator
@@ -457,6 +458,30 @@ class Settings(BaseSettings):
         default=False,
         validation_alias="QUIET_MODE",
         description="Suppress verbose logging output (set via CLI --quiet)",
+    )
+
+    # --- Untrusted Content Inspection ---
+    untrusted_content_inspection_enabled: bool = Field(
+        default=False,
+        validation_alias="UNTRUSTED_CONTENT_INSPECTION_ENABLED",
+        description="Enable content inspection for external ingress paths",
+    )
+    untrusted_content_inspection_mode: Literal["warn", "sanitize", "block"] = Field(
+        default="warn",
+        validation_alias="UNTRUSTED_CONTENT_INSPECTION_MODE",
+        description="Inspection action mode: warn | sanitize | block",
+    )
+    untrusted_content_fail_policy: Literal["fail_open", "fail_closed"] = Field(
+        default="fail_open",
+        validation_alias="UNTRUSTED_CONTENT_FAIL_POLICY",
+        description="Policy when backend errors: fail_open | fail_closed",
+    )
+    untrusted_content_backend: Literal[
+        "null", "http", "python", "subprocess", "composite"
+    ] = Field(
+        default="null",
+        validation_alias="UNTRUSTED_CONTENT_BACKEND",
+        description="Inspection backend: null | http | python | subprocess | composite",
     )
 
     # --- Telemetry & System Overrides ---

--- a/src/config.py
+++ b/src/config.py
@@ -427,6 +427,15 @@ class Settings(BaseSettings):
         validation_alias="API_RETRY_ATTEMPTS",
         description="Number of retry attempts for failed API calls",
     )
+    llm_base_output_tokens: int = Field(
+        default=32768,
+        ge=1024,
+        validation_alias="LLM_BASE_OUTPUT_TOKENS",
+        description=(
+            "Global base output-token budget used to derive per-agent caps. "
+            "Increasing this scales fractional agent budgets proportionally."
+        ),
+    )
 
     # --- Rate Limiting ---
     # Free tier: 15 RPM | Paid tier 1: 360 RPM | Tier 2: 1000+ RPM

--- a/src/data/fetcher.py
+++ b/src/data/fetcher.py
@@ -46,6 +46,7 @@ import yfinance as yf
 
 from src.config import config
 from src.data.interfaces import FinancialFetcher
+from src.ticker_policy import allows_search_resolution, normalize_exchange_specific_base
 from src.ticker_utils import generate_strict_search_query
 
 logger = structlog.get_logger(__name__)
@@ -1880,6 +1881,19 @@ class SmartMarketDataFetcher(FinancialFetcher):
             return {}
 
         all_text = "\n\n".join(search_results.values())
+
+        # Inspect web content before extracting structured metrics from it.
+        from src.tooling.inspection_service import INSPECTION_SERVICE
+        from src.tooling.inspector import InspectionEnvelope, SourceKind
+
+        envelope = InspectionEnvelope(
+            content_text=all_text,
+            source_kind=SourceKind.web_search,
+            source_name="tavily",
+            metadata={"symbol": symbol, "fields": list(search_results.keys())},
+        )
+        all_text = await INSPECTION_SERVICE.check(envelope)
+
         return self.pattern_extractor.extract_from_text(all_text, skip_fields=set())
 
     def _merge_gap_fill_data(
@@ -2223,10 +2237,7 @@ class SmartMarketDataFetcher(FinancialFetcher):
         if not self.tavily_client:
             return None
 
-        # Only attempt for markets known to use numeric codes
-        # KL=Malaysia, HK=Hong Kong, T=Japan, TW=Taiwan
-        target_suffixes = (".KL", ".HK", ".T", ".TW")
-        if not symbol.endswith(target_suffixes):
+        if not allows_search_resolution(symbol):
             return None
 
         try:
@@ -2248,14 +2259,19 @@ class SmartMarketDataFetcher(FinancialFetcher):
             )
 
             # Look for patterns like "7052.KL" or just "7052" near the company name
-            # Simple heuristic: Look for 4-digit number followed by the original suffix
-            suffix = symbol.split(".")[-1]
-            match = re.search(rf"\b(\d{{4}})\.{suffix}\b", content, re.IGNORECASE)
+            # Only rescue when the result stays on the exact same exchange suffix.
+            _, suffix = symbol.rsplit(".", 1)
+            match = re.search(
+                rf"\b(\d{{4}})\.{re.escape(suffix)}\b", content, re.IGNORECASE
+            )
 
             if match:
-                resolved = match.group(0).upper()
+                resolved_base = normalize_exchange_specific_base(
+                    match.group(1), f".{suffix}"
+                )
+                resolved = f"{resolved_base}.{suffix}".upper()
                 # Sanity check: Ensure it's different from input
-                if resolved != symbol:
+                if resolved != symbol.upper():
                     return resolved
 
             return None

--- a/src/data/filings/edinet_fetcher.py
+++ b/src/data/filings/edinet_fetcher.py
@@ -42,8 +42,8 @@ def _safe_float(value) -> float | None:
         return None
 
 
-def _extract_ticker_number(ticker: str) -> str:
-    """Extract the numeric part from a ticker like '2767.T' -> '2767'."""
+def _extract_ticker_base(ticker: str) -> str:
+    """Extract the exchange-qualified base from a ticker like '2767.T' -> '2767'."""
     return ticker.split(".")[0]
 
 
@@ -69,10 +69,10 @@ class EdinetFetcher(FilingFetcher):
             logger.warning("edinet_tools_not_installed")
             return None
 
-        ticker_num = _extract_ticker_number(ticker)
+        ticker_base = _extract_ticker_base(ticker)
 
         # Look up entity in EDINET
-        entity = await asyncio.to_thread(edinet_tools.entity, ticker_num)
+        entity = await asyncio.to_thread(edinet_tools.entity, ticker_base)
         if entity is None:
             logger.info("edinet_entity_not_found", ticker=ticker)
             return None

--- a/src/editor_tools.py
+++ b/src/editor_tools.py
@@ -11,6 +11,8 @@ from bs4 import BeautifulSoup
 from langchain_core.tools import tool
 
 from src.runtime_diagnostics import classify_failure
+from src.tooling.inspection_service import INSPECTION_SERVICE
+from src.tooling.inspector import InspectionEnvelope, SourceKind
 
 logger = structlog.get_logger(__name__)
 
@@ -81,7 +83,14 @@ async def fetch_reference_content(url: str) -> str:
             chars=len(text),
         )
 
-        return text
+        envelope = InspectionEnvelope(
+            content_text=text,
+            source_kind=SourceKind.web_fetch,
+            source_name="httpx",
+            source_uri=url,
+            metadata={"url": url[:200]},
+        )
+        return await INSPECTION_SERVICE.check(envelope)
 
     except httpx.TimeoutException:
         logger.warning("reference_fetch_timeout", url=url[:80], failure_kind="timeout")
@@ -150,11 +159,12 @@ async def search_claim(query: str) -> str:
         if not result:
             return "SEARCH_UNAVAILABLE: Tavily search returned no results (API may be unavailable)"
 
-        # Parse results — tavily_search_with_timeout returns raw tool output
+        if isinstance(result, str) and result.startswith("TOOL_BLOCKED:"):
+            return result
+
         text = str(result)
         if len(text) > MAX_CLAIM_SEARCH_CHARS:
             text = text[:MAX_CLAIM_SEARCH_CHARS] + "...[truncated]"
-
         logger.info("claim_search_complete", query=query[:80], result_chars=len(text))
         return text
 

--- a/src/graph/components.py
+++ b/src/graph/components.py
@@ -21,6 +21,7 @@ from src.agents import (
 )
 from src.charts.chart_node import create_chart_generator_node
 from src.config import config
+from src.llm_budgets import get_agent_output_budget
 from src.llms import (
     create_auditor_llm,
     create_deep_thinking_llm,
@@ -166,32 +167,50 @@ def build_graph_components(
     )
 
     tracker = get_tracker()
+    base_output_tokens = config.llm_base_output_tokens
+
+    def output_budget(agent_name: str) -> int:
+        return get_agent_output_budget(agent_name, base_output_tokens)
+
+    def tracked_callbacks(agent_name: str) -> list[TokenTrackingCallback]:
+        return [
+            TokenTrackingCallback(
+                agent_name,
+                tracker,
+                output_token_cap=output_budget(agent_name),
+            )
+        ]
 
     market_llm = create_quick_thinking_llm(
-        callbacks=[TokenTrackingCallback("Market Analyst", tracker)]
+        callbacks=tracked_callbacks("Market Analyst"),
+        max_output_tokens=output_budget("Market Analyst"),
     )
     social_llm = create_quick_thinking_llm(
-        callbacks=[TokenTrackingCallback("Sentiment Analyst", tracker)]
+        callbacks=tracked_callbacks("Sentiment Analyst"),
+        max_output_tokens=output_budget("Sentiment Analyst"),
     )
     news_llm = create_quick_thinking_llm(
-        callbacks=[TokenTrackingCallback("News Analyst", tracker)]
+        callbacks=tracked_callbacks("News Analyst"),
+        max_output_tokens=output_budget("News Analyst"),
     )
     junior_fund_llm = create_quick_thinking_llm(
-        callbacks=[TokenTrackingCallback("Junior Fundamentals Analyst", tracker)]
+        callbacks=tracked_callbacks("Junior Fundamentals Analyst"),
+        max_output_tokens=output_budget("Junior Fundamentals Analyst"),
     )
     # Senior Fundamentals stays on the quick model even in normal mode.
     # This node does structured synthesis over large upstream inputs; using the
     # deep/thinking-heavy model here has historically increased timeout risk
     # without improving downstream scoring quality enough to justify it.
     senior_fund_llm = create_quick_thinking_llm(
-        callbacks=[TokenTrackingCallback("Fundamentals Analyst", tracker)]
+        callbacks=tracked_callbacks("Fundamentals Analyst"),
+        max_output_tokens=output_budget("Fundamentals Analyst"),
     )
 
     retry_llm = None
     allow_retry = False
     if not quick_mode and is_gemini_v3_or_greater(config.quick_think_llm):
         retry_llm = create_deep_thinking_llm(
-            callbacks=[TokenTrackingCallback("Retry Agent (Deep)", tracker)]
+            callbacks=tracked_callbacks("Retry Agent (Deep)"),
         )
         allow_retry = True
         logger.info("retry_llm_enabled", ticker=ticker)
@@ -201,66 +220,84 @@ def build_graph_components(
     if quick_mode:
         logger.info("synthesis_llm_mode", quick_mode=quick_mode, thinking_level="low")
         bull_llm = create_quick_thinking_llm(
-            callbacks=[TokenTrackingCallback("Bull Researcher", tracker)]
+            callbacks=tracked_callbacks("Bull Researcher"),
+            max_output_tokens=output_budget("Bull Researcher"),
         )
         bear_llm = create_quick_thinking_llm(
-            callbacks=[TokenTrackingCallback("Bear Researcher", tracker)]
+            callbacks=tracked_callbacks("Bear Researcher"),
+            max_output_tokens=output_budget("Bear Researcher"),
         )
         res_mgr_llm = create_quick_thinking_llm(
-            callbacks=[TokenTrackingCallback("Research Manager", tracker)]
+            callbacks=tracked_callbacks("Research Manager"),
+            max_output_tokens=output_budget("Research Manager"),
         )
         pm_llm = create_quick_thinking_llm(
-            callbacks=[TokenTrackingCallback("Portfolio Manager", tracker)]
+            callbacks=tracked_callbacks("Portfolio Manager"),
+            max_output_tokens=output_budget("Portfolio Manager"),
         )
         risky_llm = create_quick_thinking_llm(
-            callbacks=[TokenTrackingCallback("Risky Analyst", tracker)]
+            callbacks=tracked_callbacks("Risky Analyst"),
+            max_output_tokens=output_budget("Risky Analyst"),
         )
         safe_llm = create_quick_thinking_llm(
-            callbacks=[TokenTrackingCallback("Safe Analyst", tracker)]
+            callbacks=tracked_callbacks("Safe Analyst"),
+            max_output_tokens=output_budget("Safe Analyst"),
         )
         neutral_llm = create_quick_thinking_llm(
-            callbacks=[TokenTrackingCallback("Neutral Analyst", tracker)]
+            callbacks=tracked_callbacks("Neutral Analyst"),
+            max_output_tokens=output_budget("Neutral Analyst"),
         )
     else:
         logger.info("synthesis_llm_mode", quick_mode=quick_mode, thinking_level="high")
         bull_llm = create_deep_thinking_llm(
-            callbacks=[TokenTrackingCallback("Bull Researcher", tracker)]
+            callbacks=tracked_callbacks("Bull Researcher"),
+            max_output_tokens=output_budget("Bull Researcher"),
         )
         bear_llm = create_deep_thinking_llm(
-            callbacks=[TokenTrackingCallback("Bear Researcher", tracker)]
+            callbacks=tracked_callbacks("Bear Researcher"),
+            max_output_tokens=output_budget("Bear Researcher"),
         )
         res_mgr_llm = create_deep_thinking_llm(
-            callbacks=[TokenTrackingCallback("Research Manager", tracker)]
+            callbacks=tracked_callbacks("Research Manager"),
+            max_output_tokens=output_budget("Research Manager"),
         )
         pm_llm = create_deep_thinking_llm(
-            callbacks=[TokenTrackingCallback("Portfolio Manager", tracker)]
+            callbacks=tracked_callbacks("Portfolio Manager"),
+            max_output_tokens=output_budget("Portfolio Manager"),
         )
         risky_llm = create_deep_thinking_llm(
-            callbacks=[TokenTrackingCallback("Risky Analyst", tracker)]
+            callbacks=tracked_callbacks("Risky Analyst"),
+            max_output_tokens=output_budget("Risky Analyst"),
         )
         safe_llm = create_deep_thinking_llm(
-            callbacks=[TokenTrackingCallback("Safe Analyst", tracker)]
+            callbacks=tracked_callbacks("Safe Analyst"),
+            max_output_tokens=output_budget("Safe Analyst"),
         )
         neutral_llm = create_deep_thinking_llm(
-            callbacks=[TokenTrackingCallback("Neutral Analyst", tracker)]
+            callbacks=tracked_callbacks("Neutral Analyst"),
+            max_output_tokens=output_budget("Neutral Analyst"),
         )
 
     trader_llm = create_quick_thinking_llm(
-        callbacks=[TokenTrackingCallback("Trader", tracker)]
+        callbacks=tracked_callbacks("Trader"),
+        max_output_tokens=output_budget("Trader"),
     )
     valuation_llm = create_quick_thinking_llm(
-        callbacks=[TokenTrackingCallback("Valuation Calculator", tracker)]
+        callbacks=tracked_callbacks("Valuation Calculator"),
+        max_output_tokens=output_budget("Valuation Calculator"),
     )
 
     consultant_llm = get_consultant_llm(
-        callbacks=[TokenTrackingCallback("Consultant", tracker)],
+        callbacks=tracked_callbacks("Consultant"),
         quick_mode=quick_mode,
+        max_completion_tokens=output_budget("Consultant"),
     )
 
     auditor_requested = _is_auditor_enabled()
     auditor_llm = (
         create_auditor_llm(
-            callbacks=[TokenTrackingCallback("Global Forensic Auditor", tracker)]
+            callbacks=tracked_callbacks("Global Forensic Auditor"),
+            max_completion_tokens=output_budget("Global Forensic Auditor"),
         )
         if auditor_requested
         else None
@@ -309,7 +346,8 @@ def build_graph_components(
     )
 
     foreign_llm = create_quick_thinking_llm(
-        callbacks=[TokenTrackingCallback("Foreign Language Analyst", tracker)]
+        callbacks=tracked_callbacks("Foreign Language Analyst"),
+        max_output_tokens=output_budget("Foreign Language Analyst"),
     )
     foreign_analyst = create_analyst_node(
         foreign_llm,
@@ -321,12 +359,14 @@ def build_graph_components(
     )
 
     legal_llm = create_quick_thinking_llm(
-        callbacks=[TokenTrackingCallback("Legal Counsel", tracker)]
+        callbacks=tracked_callbacks("Legal Counsel"),
+        max_output_tokens=output_budget("Legal Counsel"),
     )
     legal_counsel = create_legal_counsel_node(legal_llm, toolkit.get_legal_tools())
 
     value_trap_llm = create_quick_thinking_llm(
-        callbacks=[TokenTrackingCallback("Value Trap Detector", tracker)]
+        callbacks=tracked_callbacks("Value Trap Detector"),
+        max_output_tokens=output_budget("Value Trap Detector"),
     )
     value_trap_detector = create_analyst_node(
         value_trap_llm,

--- a/src/health_check.py
+++ b/src/health_check.py
@@ -4,7 +4,9 @@ Health check script for container health monitoring.
 Tests core system components without running full analysis.
 Updated for Gemini 3 Migration (Nov 2025).
 
-Run with:  poetry run python src/health_check.py
+Run with:  python src/health_check.py
+Manual repo mode without an activated venv can instead use:
+  poetry run python src/health_check.py
 """
 
 import asyncio

--- a/src/ibkr/reconciler.py
+++ b/src/ibkr/reconciler.py
@@ -48,6 +48,7 @@ from src.ibkr.order_builder import (
     round_to_lot_size,
 )
 from src.ibkr.ticker import Ticker
+from src.ticker_policy import is_safe_symbol_crossmatch_base, split_ticker
 from src.ticker_utils import TickerFormatter
 
 logger = structlog.get_logger(__name__)
@@ -1136,10 +1137,8 @@ def reconcile(
     _alpha_base_lookup: dict[str, AnalysisRecord] = {}
     _alpha_base_to_key: dict[str, str] = {}  # base → the analyses key that was chosen
     for _yf_t, _rec in analyses.items():
-        _base = (_yf_t.rsplit(".", 1)[0] if "." in _yf_t else _yf_t).upper()
-        if re.match(
-            r"^[A-Z][A-Z0-9]*$", _base
-        ):  # starts with a letter → not purely numeric
+        _base, _suffix = split_ticker(_yf_t)
+        if is_safe_symbol_crossmatch_base(_base):
             if "." in _yf_t:
                 # Suffixed entry is more specific — always overwrite any bare entry
                 _alpha_base_lookup[_base] = _rec

--- a/src/llm_budgets.py
+++ b/src/llm_budgets.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from fractions import Fraction
+
+# These fractions intentionally preserve large headroom for structured and
+# final-decision nodes while tightening naturally short-form agents.
+AGENT_OUTPUT_BUDGET_FRACTIONS: dict[str, Fraction] = {
+    "Market Analyst": Fraction(1, 16),
+    "Sentiment Analyst": Fraction(1, 32),
+    "News Analyst": Fraction(1, 16),
+    "Foreign Language Analyst": Fraction(1, 16),
+    "Legal Counsel": Fraction(1, 16),
+    "Value Trap Detector": Fraction(1, 16),
+    "Valuation Calculator": Fraction(1, 32),
+    "Global Forensic Auditor": Fraction(1, 4),
+    "Trader": Fraction(1, 8),
+    "Risky Analyst": Fraction(1, 8),
+    "Safe Analyst": Fraction(1, 8),
+    "Neutral Analyst": Fraction(1, 8),
+    "Consultant": Fraction(1, 8),
+    "Bull Researcher": Fraction(3, 16),
+    "Bear Researcher": Fraction(3, 16),
+    "Research Manager": Fraction(1, 4),
+    "Fundamentals Analyst": Fraction(1, 3),
+    "Junior Fundamentals Analyst": Fraction(1, 3),
+    "Portfolio Manager": Fraction(1, 2),
+}
+
+DEFAULT_AGENT_BUDGET_FRACTION = Fraction(1, 1)
+
+
+def get_agent_output_budget(agent_name: str, base_tokens: int) -> int:
+    """Return the configured output budget for the given agent."""
+    fraction = AGENT_OUTPUT_BUDGET_FRACTIONS.get(
+        agent_name, DEFAULT_AGENT_BUDGET_FRACTION
+    )
+    # Ceiling division preserves the intended fraction when base tokens do not
+    # divide cleanly (for example 32768 * 1/3).
+    return max(
+        256,
+        (base_tokens * fraction.numerator + fraction.denominator - 1)
+        // fraction.denominator,
+    )

--- a/src/llms.py
+++ b/src/llms.py
@@ -208,6 +208,7 @@ def create_gemini_model(
     streaming: bool = False,
     callbacks: list[BaseCallbackHandler] | None = None,
     thinking_level: str | None = None,
+    max_output_tokens: int | None = None,
 ) -> BaseChatModel:
     """
     Generic factory for Gemini models.
@@ -229,7 +230,7 @@ def create_gemini_model(
         "streaming": streaming,
         "rate_limiter": GLOBAL_RATE_LIMITER,
         "convert_system_message_to_human": False,
-        "max_output_tokens": 32768,
+        "max_output_tokens": max_output_tokens or config.llm_base_output_tokens,
         "callbacks": callbacks or [],
         "api_key": config.get_google_api_key(),  # Explicit API key from config
     }
@@ -241,6 +242,7 @@ def create_gemini_model(
         )
 
     llm = ChatGoogleGenerativeAI(**kwargs)
+    llm._configured_max_output_tokens = kwargs["max_output_tokens"]
 
     # Track instance for cleanup
     _llm_instance_counter += 1
@@ -256,6 +258,7 @@ def create_quick_thinking_llm(
     timeout: int = None,
     max_retries: int = None,
     callbacks: list[BaseCallbackHandler] | None = None,
+    max_output_tokens: int | None = None,
 ) -> BaseChatModel:
     """
     Create a quick thinking LLM.
@@ -284,6 +287,7 @@ def create_quick_thinking_llm(
         final_retries,
         callbacks=callbacks,
         thinking_level=thinking_level,
+        max_output_tokens=max_output_tokens,
     )
 
 
@@ -293,6 +297,7 @@ def create_deep_thinking_llm(
     timeout: int = None,
     max_retries: int = None,
     callbacks: list[BaseCallbackHandler] | None = None,
+    max_output_tokens: int | None = None,
 ) -> BaseChatModel:
     """
     Create a deep thinking LLM.
@@ -318,6 +323,7 @@ def create_deep_thinking_llm(
         final_retries,
         callbacks=callbacks,
         thinking_level=thinking_level,
+        max_output_tokens=max_output_tokens,
     )
 
 
@@ -335,6 +341,7 @@ def create_consultant_llm(
     max_retries: int = 0,
     quick_mode: bool = False,
     callbacks: list[BaseCallbackHandler] | None = None,
+    max_completion_tokens: int | None = None,
 ) -> BaseChatModel:
     """
     Create an OpenAI consultant LLM for cross-validation.
@@ -419,7 +426,7 @@ def create_consultant_llm(
         "callbacks": callbacks or [],
         # Keep the consultant concise enough for bounded latency on multi-turn
         # tool use while leaving ample room for structured critique.
-        "max_completion_tokens": 8192,
+        "max_completion_tokens": max_completion_tokens or 8192,
         "streaming": False,
         "use_responses_api": True,
         "output_version": "responses/v1",
@@ -432,12 +439,14 @@ def create_consultant_llm(
         kwargs["reasoning_effort"] = "medium"
 
     llm = ChatOpenAI(**kwargs)
+    llm._configured_max_completion_tokens = kwargs["max_completion_tokens"]
 
     return llm
 
 
 def create_auditor_llm(
     callbacks: list[BaseCallbackHandler] | None = None,
+    max_completion_tokens: int | None = None,
 ) -> BaseChatModel | None:
     """
     Create Auditor LLM with fallback logic.
@@ -480,13 +489,15 @@ def create_auditor_llm(
         "max_retries": 3,
         "api_key": api_key,
         "callbacks": callbacks or [],
-        "max_completion_tokens": 16384,
+        "max_completion_tokens": max_completion_tokens or 16384,
         "streaming": False,
         "use_responses_api": True,
         "output_version": "responses/v1",
     }
 
-    return ChatOpenAI(**kwargs)
+    llm = ChatOpenAI(**kwargs)
+    llm._configured_max_completion_tokens = kwargs["max_completion_tokens"]
+    return llm
 
 
 def create_writer_llm(
@@ -631,7 +642,9 @@ _consultant_llm_instance = None
 
 
 def get_consultant_llm(
-    callbacks: list[BaseCallbackHandler] | None = None, quick_mode: bool = False
+    callbacks: list[BaseCallbackHandler] | None = None,
+    quick_mode: bool = False,
+    max_completion_tokens: int | None = None,
 ) -> BaseChatModel | None:
     """
     Get or create the consultant LLM instance.
@@ -672,7 +685,9 @@ def get_consultant_llm(
     if _consultant_llm_instance is None:
         try:
             _consultant_llm_instance = create_consultant_llm(
-                callbacks=callbacks, quick_mode=quick_mode
+                callbacks=callbacks,
+                quick_mode=quick_mode,
+                max_completion_tokens=max_completion_tokens,
             )
         except Exception as e:
             logger.error(

--- a/src/main.py
+++ b/src/main.py
@@ -436,11 +436,56 @@ def configure_tool_audit_logging(enabled: bool) -> None:
     from src.tooling.audit import LoggingToolAuditHook
     from src.tooling.runtime import TOOL_SERVICE
 
+    hooks = [h for h in TOOL_SERVICE.hooks if not isinstance(h, LoggingToolAuditHook)]
     if enabled:
-        TOOL_SERVICE.set_hooks([LoggingToolAuditHook()])
+        hooks.insert(0, LoggingToolAuditHook())
+        TOOL_SERVICE.set_hooks(hooks)
         logger.info("tool_audit_logging_enabled")
     else:
-        TOOL_SERVICE.clear_hooks()
+        TOOL_SERVICE.set_hooks(hooks)
+
+
+def configure_content_inspection_from_config() -> None:
+    """Wire up content inspection from config settings.
+
+    Called independently of logging configuration — security inspection must
+    not be gated on CLI verbosity flags.
+    """
+    from src.tooling.inspection_hook import ContentInspectionHook
+    from src.tooling.inspection_service import configure_content_inspection
+    from src.tooling.inspector import NullInspector
+    from src.tooling.runtime import TOOL_SERVICE
+
+    hooks = [h for h in TOOL_SERVICE.hooks if not isinstance(h, ContentInspectionHook)]
+
+    if not config.untrusted_content_inspection_enabled:
+        TOOL_SERVICE.set_hooks(hooks)
+        configure_content_inspection(
+            NullInspector(), mode="warn", fail_policy="fail_open"
+        )
+        return
+
+    mode = config.untrusted_content_inspection_mode
+    fail_policy = config.untrusted_content_fail_policy
+    backend_name = config.untrusted_content_backend
+
+    if backend_name == "null" or not backend_name:
+        inspector = NullInspector()
+    else:
+        raise ValueError(
+            "UNTRUSTED_CONTENT_BACKEND is set to "
+            f"{backend_name!r}, but only 'null' is implemented in this branch."
+        )
+
+    configure_content_inspection(inspector, mode=mode, fail_policy=fail_policy)
+    hooks.append(ContentInspectionHook())
+    TOOL_SERVICE.set_hooks(hooks)
+    logger.info(
+        "content_inspection_enabled",
+        mode=mode,
+        fail_policy=fail_policy,
+        backend=backend_name,
+    )
 
 
 def configure_cli_logging(args) -> dict[str, dict[str, str]]:
@@ -1399,6 +1444,16 @@ def _setup_runtime(
             console.print(
                 "Please check your .env file and ensure all required API keys are set.\n"
             )
+        raise SystemExit(1) from exc
+
+    # Content inspection is configured independently of logging verbosity.
+    try:
+        configure_content_inspection_from_config()
+    except ValueError as exc:
+        if args.quiet or args.brief:
+            print(f"# Configuration Error\n\n{str(exc)}")
+        else:
+            console.print(f"\n[bold red]Configuration Error:[/bold red] {str(exc)}\n")
         raise SystemExit(1) from exc
 
     return provider_preflight

--- a/src/report_generator.py
+++ b/src/report_generator.py
@@ -705,7 +705,7 @@ NOTE: If price is above fair value midpoint but verdict is BUY, you MUST explain
 4. Memory/resource constraints
 
 **Action Required**:
-Re-run analysis with verbose logging: `poetry run python -m src.main --ticker {self.ticker}`
+Re-run analysis with verbose logging: `python -m src.main --ticker {self.ticker}` (or prefix with `poetry run` in manual repo mode)
 """
         return error_msg
 

--- a/src/tavily_utils.py
+++ b/src/tavily_utils.py
@@ -9,6 +9,9 @@ from typing import Any
 
 import structlog
 
+from src.tooling.inspection_service import INSPECTION_SERVICE
+from src.tooling.inspector import InspectionEnvelope, SourceKind
+
 logger = structlog.get_logger(__name__)
 
 # Tavily timeout configuration (seconds)
@@ -31,17 +34,19 @@ async def tavily_search_with_timeout(
     """
     Execute Tavily search with timeout protection.
 
+    All results pass through INSPECTION_SERVICE before being returned to callers.
+
     Args:
         query: Query dict for tavily_tool.ainvoke (e.g., {"query": "search terms"})
         timeout: Maximum seconds to wait (default: TAVILY_TIMEOUT_SECONDS)
 
     Returns:
-        Tavily search results, or None if timeout/error occurs
+        Tavily search results (inspected), or None if timeout/error occurs
     """
     if not _tavily_tool:
         return None
     try:
-        return await asyncio.wait_for(_tavily_tool.ainvoke(query), timeout=timeout)
+        raw = await asyncio.wait_for(_tavily_tool.ainvoke(query), timeout=timeout)
     except asyncio.TimeoutError:
         logger.warning(
             "tavily_search_timeout",
@@ -56,3 +61,20 @@ async def tavily_search_with_timeout(
             error=str(e),
         )
         return None
+
+    if raw is None:
+        return None
+
+    content_text = raw if isinstance(raw, str) else str(raw)
+    envelope = InspectionEnvelope(
+        content_text=content_text,
+        raw_content=raw,
+        source_kind=SourceKind.web_search,
+        source_name="tavily",
+        metadata={"query": query.get("query", "")[:200]},
+    )
+    approved = await INSPECTION_SERVICE.check(envelope)
+
+    # Preserve the original payload shape on allow/fail-open paths so callers
+    # that merge structured Tavily results do not regress.
+    return approved

--- a/src/ticker_policy.py
+++ b/src/ticker_policy.py
@@ -1,0 +1,50 @@
+"""Exchange-qualified ticker policy helpers.
+
+This module keeps a small set of ticker-shape rules in one place so that
+callers do not quietly drift into exchange-unsafe assumptions.
+"""
+
+from __future__ import annotations
+
+_SEARCH_RESOLUTION_SUFFIXES = frozenset({".HK", ".KL", ".TW", ".TWO"})
+
+
+def split_ticker(ticker: str) -> tuple[str, str]:
+    """Split a ticker into base symbol and normalized suffix."""
+    cleaned = ticker.strip().upper()
+    if "." not in cleaned:
+        return cleaned, ""
+    base, suffix = cleaned.rsplit(".", 1)
+    return base, f".{suffix}"
+
+
+def is_pure_numeric_base(base: str) -> bool:
+    """Return True when the base symbol is all digits."""
+    return bool(base) and base.isdigit()
+
+
+def is_safe_symbol_crossmatch_base(base: str) -> bool:
+    """Return True when a base symbol is safe for suffix-agnostic matching."""
+    return bool(base) and not is_pure_numeric_base(base)
+
+
+def allows_search_resolution(ticker: str) -> bool:
+    """Return True when search-based symbol rescue is allowed for this ticker."""
+    _, suffix = split_ticker(ticker)
+    return suffix in _SEARCH_RESOLUTION_SUFFIXES
+
+
+def normalize_exchange_specific_base(base: str, suffix: str) -> str:
+    """Normalize a base symbol only where exchange rules are well-defined."""
+    normalized_base = base.strip().upper()
+    normalized_suffix = suffix.strip().upper()
+    if normalized_suffix == ".HK" and normalized_base.isdigit():
+        return normalized_base.zfill(4)
+    return normalized_base
+
+
+def same_exchange(ticker_a: str, ticker_b: str) -> bool:
+    """Return True when two tickers share the same explicit exchange suffix."""
+    _, suffix_a = split_ticker(ticker_a)
+    _, suffix_b = split_ticker(ticker_b)
+    return suffix_a == suffix_b

--- a/src/token_tracker.py
+++ b/src/token_tracker.py
@@ -320,7 +320,12 @@ class TokenTrackingCallback(BaseCallbackHandler):
     Attach this to LLM instances to automatically log token consumption.
     """
 
-    def __init__(self, agent_name: str, tracker: TokenTracker | None = None):
+    def __init__(
+        self,
+        agent_name: str,
+        tracker: TokenTracker | None = None,
+        output_token_cap: int | None = None,
+    ):
         """
         Initialize callback with agent name.
 
@@ -331,6 +336,7 @@ class TokenTrackingCallback(BaseCallbackHandler):
         super().__init__()
         self.agent_name = agent_name
         self.tracker = tracker or TokenTracker()
+        self.output_token_cap = output_token_cap
 
     def on_llm_end(self, response: LLMResult, **kwargs: Any) -> None:
         """Called when LLM completes a generation."""
@@ -388,6 +394,17 @@ class TokenTrackingCallback(BaseCallbackHandler):
                     prompt_tokens=prompt_tokens,
                     completion_tokens=completion_tokens,
                 )
+                if self.output_token_cap and completion_tokens > 0:
+                    logger.info(
+                        "llm_output_budget_usage",
+                        agent=self.agent_name,
+                        model=model_name,
+                        configured_output_cap=self.output_token_cap,
+                        completion_tokens=completion_tokens,
+                        utilization_ratio=round(
+                            completion_tokens / self.output_token_cap, 4
+                        ),
+                    )
 
 
 # Global singleton instance (lazy initialization to respect quiet mode)

--- a/src/tooling/__init__.py
+++ b/src/tooling/__init__.py
@@ -1,6 +1,20 @@
-"""Shared tool execution and auditing primitives."""
+"""Shared tool execution, auditing, and content inspection primitives."""
 
 from src.tooling.audit import LoggingToolAuditHook
+from src.tooling.inspection_hook import ContentInspectionHook
+from src.tooling.inspection_service import (
+    INSPECTION_SERVICE,
+    InspectionService,
+    configure_content_inspection,
+)
+from src.tooling.inspector import (
+    CompositeInspector,
+    ContentInspector,
+    InspectionDecision,
+    InspectionEnvelope,
+    NullInspector,
+    SourceKind,
+)
 from src.tooling.runtime import (
     TOOL_SERVICE,
     ToolCallBlocked,
@@ -11,7 +25,20 @@ from src.tooling.runtime import (
 )
 
 __all__ = [
+    # Audit
     "LoggingToolAuditHook",
+    # Content inspection
+    "CompositeInspector",
+    "ContentInspectionHook",
+    "ContentInspector",
+    "INSPECTION_SERVICE",
+    "InspectionDecision",
+    "InspectionEnvelope",
+    "InspectionService",
+    "NullInspector",
+    "SourceKind",
+    "configure_content_inspection",
+    # Tool execution
     "TOOL_SERVICE",
     "ToolCallBlocked",
     "ToolExecutionService",

--- a/src/tooling/inspection_hook.py
+++ b/src/tooling/inspection_hook.py
@@ -1,0 +1,80 @@
+"""TOOL_SERVICE hook adapter for content inspection.
+
+ContentInspectionHook plugs into the ToolExecutionService hook chain and
+inspects every tool output via the global INSPECTION_SERVICE singleton
+before the result reaches an LLM context.
+
+The hook operates exclusively in after() — it never raises ToolCallBlocked
+because after() is called outside the before()-try/catch block in
+ToolExecutionService.execute(). Instead, blocked content is returned as
+a modified ToolResult with the legacy ``TOOL_BLOCKED:`` sentinel and
+blocked=True.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from src.tooling.inspection_service import INSPECTION_SERVICE
+from src.tooling.inspector import InspectionEnvelope, SourceKind
+from src.tooling.runtime import ToolInvocation, ToolResult
+
+logger = structlog.get_logger(__name__)
+
+
+class ContentInspectionHook:
+    """Inspect tool outputs through the global INSPECTION_SERVICE.
+
+    Install via::
+
+        TOOL_SERVICE.add_hook(ContentInspectionHook())
+    """
+
+    async def before(self, call: ToolInvocation) -> ToolInvocation:
+        return call  # pass-through
+
+    async def after(self, call: ToolInvocation, result: ToolResult) -> ToolResult:
+        if result.blocked:
+            # Already blocked by a prior hook — nothing to inspect.
+            return result
+
+        content_text = (
+            result.value if isinstance(result.value, str) else str(result.value)
+        )
+
+        envelope = InspectionEnvelope(
+            content_text=content_text,
+            raw_content=result.value,
+            source_kind=SourceKind.tool_output,
+            source_name=call.name,
+            tool_name=call.name,
+            agent_key=call.agent_key,
+            metadata={
+                "source": call.source,
+                "args_keys": list(call.args.keys()) if call.args else [],
+            },
+        )
+
+        approved = await INSPECTION_SERVICE.check(envelope)
+
+        if approved is result.value:
+            return result
+
+        # Content was sanitized or blocked.
+        blocked = isinstance(approved, str) and approved.startswith("TOOL_BLOCKED:")
+        findings = result.findings or []
+        if blocked:
+            logger.warning(
+                "tool_call_blocked",
+                tool=call.name,
+                source=call.source,
+                agent_key=call.agent_key,
+                reason=approved,
+            )
+            findings = findings + [approved]
+
+        return ToolResult(
+            value=approved,
+            blocked=blocked,
+            findings=findings if findings else None,
+        )

--- a/src/tooling/inspection_service.py
+++ b/src/tooling/inspection_service.py
@@ -1,0 +1,170 @@
+"""InspectionService — policy layer that wraps a ContentInspector backend.
+
+Usage
+-----
+The module exposes a ``INSPECTION_SERVICE`` singleton pre-configured with a
+``NullInspector`` (zero overhead, always allows).  Call
+``configure_content_inspection()`` at application startup to swap in a real
+backend and mode.
+
+Every external-content callsite should call::
+
+    approved = await INSPECTION_SERVICE.check(InspectionEnvelope(...))
+
+and use the returned approved value in place of the raw content. When the
+inspector allows the content, the original ``raw_content`` value is preserved
+when available so structured payload shapes are not lost.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import structlog
+
+from src.tooling.inspector import (
+    ContentInspector,
+    InspectionDecision,
+    InspectionEnvelope,
+    NullInspector,
+)
+
+logger = structlog.get_logger(__name__)
+
+_BLOCKED_PLACEHOLDER = "TOOL_BLOCKED: {reason}"
+
+
+class InspectionService:
+    """Apply an inspection decision to produce an approved content value.
+
+    Modes:
+        warn      — log findings, return original content unchanged
+        sanitize  — replace with sanitized_content when provided, else warn
+        block     — return a CONTENT_BLOCKED placeholder string
+
+    Fail policies:
+        fail_open   — if the backend raises, allow the content through
+        fail_closed — if the backend raises, treat as blocked
+    """
+
+    def __init__(
+        self,
+        inspector: ContentInspector | None = None,
+        mode: Literal["warn", "sanitize", "block"] = "warn",
+        fail_policy: Literal["fail_open", "fail_closed"] = "fail_open",
+    ) -> None:
+        self._inspector: ContentInspector = inspector or NullInspector()
+        self._mode = mode
+        self._fail_policy = fail_policy
+
+    def configure(
+        self,
+        inspector: ContentInspector,
+        mode: Literal["warn", "sanitize", "block"] = "warn",
+        fail_policy: Literal["fail_open", "fail_closed"] = "fail_open",
+    ) -> None:
+        """Reconfigure the service (called at startup by configure_content_inspection)."""
+        self._inspector = inspector
+        self._mode = mode
+        self._fail_policy = fail_policy
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    async def check(self, envelope: InspectionEnvelope) -> Any:
+        """Inspect *envelope* and return the approved content string.
+
+        Returns the original value, a sanitized replacement string, or a
+        blocked-placeholder string depending on the decision and configured mode.
+        """
+        original_value = (
+            envelope.raw_content
+            if envelope.raw_content is not None
+            else envelope.content_text
+        )
+        try:
+            decision: InspectionDecision = await self._inspector.inspect(envelope)
+        except Exception as exc:
+            if self._fail_policy == "fail_closed":
+                reason = f"inspector error: {exc}"
+                logger.error(
+                    "content_inspection_backend_error",
+                    source_kind=envelope.source_kind.value,
+                    source_name=envelope.source_name,
+                    error=str(exc),
+                    fail_policy=self._fail_policy,
+                )
+                return _BLOCKED_PLACEHOLDER.format(reason=reason)
+            logger.warning(
+                "content_inspection_backend_error",
+                source_kind=envelope.source_kind.value,
+                source_name=envelope.source_name,
+                error=str(exc),
+                fail_policy=self._fail_policy,
+            )
+            return original_value
+
+        if decision.action == "allow" and decision.threat_level == "safe":
+            return original_value
+
+        # Log findings for non-trivial decisions regardless of mode.
+        if decision.findings or decision.threat_types:
+            logger.warning(
+                "content_inspection_finding",
+                source_kind=envelope.source_kind.value,
+                source_name=envelope.source_name,
+                tool_name=envelope.tool_name,
+                agent_key=envelope.agent_key,
+                action=decision.action,
+                threat_level=decision.threat_level,
+                threat_types=decision.threat_types,
+                confidence=decision.confidence,
+                findings=decision.findings,
+                reason=decision.reason,
+            )
+
+        if decision.action in ("block", "degrade"):
+            if self._mode == "block":
+                reason = decision.reason or "; ".join(decision.findings) or "policy"
+                return _BLOCKED_PLACEHOLDER.format(reason=reason)
+            if self._mode == "sanitize" and decision.sanitized_content is not None:
+                return decision.sanitized_content
+            # warn (or sanitize-without-replacement): log and pass through
+            return original_value
+
+        if decision.action == "sanitize":
+            if self._mode in ("sanitize", "block") and decision.sanitized_content:
+                return decision.sanitized_content
+            return original_value
+
+        # action == "allow" with non-safe threat level → warn and pass through
+        return original_value
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton — pre-configured with NullInspector (zero overhead).
+# Swap at startup via configure_content_inspection().
+# ---------------------------------------------------------------------------
+
+INSPECTION_SERVICE = InspectionService()
+
+
+def configure_content_inspection(
+    inspector: ContentInspector,
+    mode: Literal["warn", "sanitize", "block"] = "warn",
+    fail_policy: Literal["fail_open", "fail_closed"] = "fail_open",
+) -> None:
+    """Install an inspection backend on the global singleton.
+
+    This configures the shared service only. Callers that want tool-output
+    inspection must also install ``ContentInspectionHook`` on ``TOOL_SERVICE``
+    or use the higher-level runtime setup path in ``src.main``.
+    """
+    INSPECTION_SERVICE.configure(inspector, mode=mode, fail_policy=fail_policy)
+    logger.info(
+        "content_inspection_configured",
+        inspector=type(inspector).__name__,
+        mode=mode,
+        fail_policy=fail_policy,
+    )

--- a/src/tooling/inspector.py
+++ b/src/tooling/inspector.py
@@ -1,0 +1,205 @@
+"""Untrusted content inspection domain model and service abstractions.
+
+This module establishes the core types for the content inspection pipeline.
+Every external-content ingress path must pass content through an
+InspectionService before that content reaches an LLM context.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Literal, Protocol, runtime_checkable
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+class SourceKind(str, Enum):
+    """Classification of the content's origin — used for policy decisions."""
+
+    tool_output = "tool_output"
+    web_search = "web_search"
+    web_fetch = "web_fetch"
+    official_filing = "official_filing"
+    social_feed = "social_feed"
+    financial_api = "financial_api"
+    mcp_tool_output = "mcp_tool_output"  # reserved for future MCP integration
+
+
+@dataclass
+class InspectionEnvelope:
+    """Rich context envelope passed to every inspection backend."""
+
+    content_text: str
+    source_kind: SourceKind
+    source_name: str
+    raw_content: Any | None = None
+    tool_name: str | None = None
+    agent_key: str | None = None
+    source_uri: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class InspectionDecision:
+    """Result returned by a ContentInspector backend."""
+
+    action: Literal["allow", "sanitize", "block", "degrade"]
+    threat_level: Literal["safe", "low", "medium", "high", "critical"]
+    threat_types: list[str] = field(default_factory=list)
+    confidence: float = 1.0
+    sanitized_content: str | None = None
+    findings: list[str] = field(default_factory=list)
+    reason: str | None = None
+
+
+@runtime_checkable
+class ContentInspector(Protocol):
+    """Protocol implemented by all inspection backends."""
+
+    async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision: ...
+
+
+class NullInspector:
+    """Default no-op inspector — always allows, zero overhead."""
+
+    async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+        return InspectionDecision(
+            action="allow",
+            threat_level="safe",
+        )
+
+
+class CompositeInspector:
+    """Chain multiple inspection backends with a configurable decision strategy.
+
+    Strategies:
+        any_block   — block if any backend says block or degrade
+        majority    — block if more than half of backends flag the content
+        first_flag  — stop at the first non-allow decision and return it
+    """
+
+    def __init__(
+        self,
+        inspectors: list[ContentInspector],
+        strategy: Literal["any_block", "majority", "first_flag"] = "any_block",
+    ) -> None:
+        self._inspectors = list(inspectors)
+        self._strategy = strategy
+
+    async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+        if not self._inspectors:
+            return InspectionDecision(action="allow", threat_level="safe")
+
+        inspection_results = await asyncio.gather(
+            *[insp.inspect(envelope) for insp in self._inspectors],
+            return_exceptions=True,
+        )
+        decisions: list[InspectionDecision] = []
+        errors: list[tuple[str, Exception]] = []
+        for inspector, result in zip(
+            self._inspectors, inspection_results, strict=False
+        ):
+            if isinstance(result, Exception):
+                errors.append((type(inspector).__name__, result))
+            else:
+                decisions.append(result)
+
+        for inspector_name, exc in errors:
+            logger.warning(
+                "content_inspector_backend_failed",
+                inspector=inspector_name,
+                strategy=self._strategy,
+                source_kind=envelope.source_kind.value,
+                source_name=envelope.source_name,
+                error=str(exc),
+            )
+
+        if not decisions:
+            if len(errors) == 1:
+                raise errors[0][1]
+            raise RuntimeError(
+                f"All {len(errors)} content inspectors failed for {envelope.source_name}"
+            )
+
+        if self._strategy == "first_flag":
+            for decision in decisions:
+                if decision.action != "allow":
+                    return decision
+            return self._most_conservative(decisions)
+
+        blocking = [d for d in decisions if d.action in ("block", "degrade")]
+
+        if self._strategy == "any_block":
+            if blocking:
+                return self._merge(blocking)
+            return self._most_conservative_non_blocking(decisions)
+
+        # majority
+        if len(blocking) > len(decisions) / 2:
+            return self._merge(blocking)
+        return self._most_conservative_non_blocking(decisions)
+
+    @staticmethod
+    def _merge(blocking: list[InspectionDecision]) -> InspectionDecision:
+        """Merge multiple blocking decisions into one."""
+        all_findings: list[str] = []
+        all_types: list[str] = []
+        for d in blocking:
+            all_findings.extend(d.findings)
+            all_types.extend(d.threat_types)
+        worst = max(
+            blocking,
+            key=lambda d: ["safe", "low", "medium", "high", "critical"].index(
+                d.threat_level
+            ),
+        )
+        return InspectionDecision(
+            action=worst.action,
+            threat_level=worst.threat_level,
+            threat_types=list(dict.fromkeys(all_types)),
+            confidence=max(d.confidence for d in blocking),
+            sanitized_content=next(
+                (d.sanitized_content for d in blocking if d.sanitized_content), None
+            ),
+            findings=all_findings,
+            reason=worst.reason,
+        )
+
+    @staticmethod
+    def _most_conservative(decisions: list[InspectionDecision]) -> InspectionDecision:
+        """Prefer the strictest available decision when no blocking merge applies."""
+
+        action_rank = {
+            "allow": 0,
+            "sanitize": 1,
+            "degrade": 2,
+            "block": 3,
+        }
+        threat_rank = {
+            "safe": 0,
+            "low": 1,
+            "medium": 2,
+            "high": 3,
+            "critical": 4,
+        }
+        return max(
+            decisions,
+            key=lambda d: (
+                action_rank[d.action],
+                threat_rank[d.threat_level],
+                d.confidence,
+            ),
+        )
+
+    @classmethod
+    def _most_conservative_non_blocking(
+        cls, decisions: list[InspectionDecision]
+    ) -> InspectionDecision:
+        non_blocking = [d for d in decisions if d.action not in ("block", "degrade")]
+        if non_blocking:
+            return cls._most_conservative(non_blocking)
+        return decisions[0]

--- a/src/tooling/runtime.py
+++ b/src/tooling/runtime.py
@@ -12,7 +12,9 @@ from src.runtime_diagnostics import classify_failure
 
 logger = structlog.get_logger(__name__)
 
-ToolSource: TypeAlias = Literal["toolnode", "consultant", "editor"]
+ToolSource: TypeAlias = Literal[
+    "toolnode", "consultant", "editor", "legal_counsel", "auditor"
+]
 
 
 class ToolCallBlocked(RuntimeError):

--- a/src/tools/news.py
+++ b/src/tools/news.py
@@ -1,5 +1,6 @@
 """News and sentiment tool implementations."""
 
+import asyncio
 from typing import Annotated
 
 import structlog
@@ -8,6 +9,8 @@ from langchain_core.tools import tool
 
 from src.stocktwits_api import StockTwitsAPI
 from src.ticker_utils import normalize_ticker
+from src.tooling.inspection_service import INSPECTION_SERVICE
+from src.tooling.inspector import InspectionEnvelope, SourceKind
 from src.tools import shared
 
 logger = structlog.get_logger(__name__)
@@ -94,6 +97,23 @@ async def get_social_media_sentiment(ticker: str) -> str:
         if "error" in data:
             return f"StockTwits Sentiment Error: {data.get('error')}"
 
+        # Inspect user-generated message content before including in summary.
+        raw_messages = data.get("messages", [])
+        inspection_tasks = []
+        for msg in raw_messages:
+            msg_text = str(msg)
+            envelope = InspectionEnvelope(
+                content_text=msg_text,
+                source_kind=SourceKind.social_feed,
+                source_name="stocktwits",
+                metadata={"ticker": ticker},
+            )
+            inspection_tasks.append(INSPECTION_SERVICE.check(envelope))
+
+        inspected_messages = (
+            await asyncio.gather(*inspection_tasks) if inspection_tasks else []
+        )
+
         summary = (
             f"StockTwits Sentiment for {data.get('ticker')}:\n"
             f"- Bullish: {data.get('bullish_pct')}% ({data.get('bullish_count')} msgs)\n"
@@ -102,9 +122,8 @@ async def get_social_media_sentiment(ticker: str) -> str:
             "Sample Messages:\n"
         )
 
-        messages = data.get("messages", [])
-        if messages:
-            for msg in messages:
+        if inspected_messages:
+            for msg in inspected_messages:
                 summary += f"- {msg}\n"
         else:
             summary += "- No recent messages found.\n"

--- a/tests/advanced/test_editor.py
+++ b/tests/advanced/test_editor.py
@@ -1750,6 +1750,19 @@ class TestSearchClaimTool:
             assert "SEARCH_UNAVAILABLE" in result
 
     @pytest.mark.asyncio
+    async def test_search_claim_preserves_blocked_sentinel_from_tavily(self):
+        """Blocked Tavily content should pass through without a second inspection pass."""
+        from src.editor_tools import search_claim
+
+        with patch(
+            "src.tavily_utils.tavily_search_with_timeout",
+            new_callable=AsyncMock,
+            return_value="TOOL_BLOCKED: suspicious content",
+        ):
+            result = await search_claim.ainvoke({"query": "test query here"})
+            assert result == "TOOL_BLOCKED: suspicious content"
+
+    @pytest.mark.asyncio
     async def test_search_truncates_long_results(self):
         """Long search results should be truncated."""
         from src.editor_tools import MAX_CLAIM_SEARCH_CHARS, search_claim

--- a/tests/advanced/test_llm_budgets.py
+++ b/tests/advanced/test_llm_budgets.py
@@ -1,0 +1,17 @@
+from src.llm_budgets import get_agent_output_budget
+
+
+def test_agent_budgets_scale_from_base_cap():
+    assert get_agent_output_budget("Sentiment Analyst", 32768) == 1024
+    assert get_agent_output_budget("Portfolio Manager", 32768) == 16384
+    assert get_agent_output_budget("Research Manager", 32768) == 8192
+
+
+def test_agent_budgets_scale_when_base_cap_doubles():
+    assert get_agent_output_budget("Sentiment Analyst", 65536) == 2048
+    assert get_agent_output_budget("Portfolio Manager", 65536) == 32768
+    assert get_agent_output_budget("Fundamentals Analyst", 65536) == 21846
+
+
+def test_unknown_agents_default_to_global_base_cap():
+    assert get_agent_output_budget("Retry Agent (Deep)", 32768) == 32768

--- a/tests/advanced/test_quickmode_scenarios.py
+++ b/tests/advanced/test_quickmode_scenarios.py
@@ -93,6 +93,7 @@ def test_quick_llm_has_no_thinking_level_on_gemini_2(
     mock_create_gemini_model.assert_called_once()
     call_kwargs = mock_create_gemini_model.call_args.kwargs
     assert call_kwargs.get("thinking_level") is None
+    assert call_kwargs.get("max_output_tokens") is None
 
 
 def test_deep_llm_sets_high_thinking_level_on_gemini_4(
@@ -131,6 +132,28 @@ def test_deep_llm_has_no_thinking_level_on_gemini_2(
     mock_create_gemini_model.assert_called_once()
     call_kwargs = mock_create_gemini_model.call_args.kwargs
     assert call_kwargs.get("thinking_level") is None
+
+
+def test_quick_llm_passes_through_max_output_tokens(
+    mock_create_gemini_model, mock_config
+):
+    mock_config.quick_think_llm = GEMINI_3_PRO
+
+    create_quick_thinking_llm(max_output_tokens=4096)
+
+    call_kwargs = mock_create_gemini_model.call_args.kwargs
+    assert call_kwargs.get("max_output_tokens") == 4096
+
+
+def test_deep_llm_passes_through_max_output_tokens(
+    mock_create_gemini_model, mock_config
+):
+    mock_config.deep_think_llm = GEMINI_4_ULTRA
+
+    create_deep_thinking_llm(max_output_tokens=8192)
+
+    call_kwargs = mock_create_gemini_model.call_args.kwargs
+    assert call_kwargs.get("max_output_tokens") == 8192
 
 
 def test_create_gemini_model_logs_thinking_level_at_debug(caplog):

--- a/tests/advanced/test_token_tracker.py
+++ b/tests/advanced/test_token_tracker.py
@@ -9,6 +9,8 @@ Tests the token tracking functionality:
 - Statistics aggregation and reporting
 """
 
+from unittest.mock import patch
+
 from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration, LLMResult
 
@@ -517,6 +519,37 @@ class TestTokenTrackingCallback:
 
         assert callback.agent_name == "test_agent"
         assert callback.tracker is not None
+
+    def test_callback_records_output_budget_usage(self):
+        """Test callback emits output budget utilization telemetry when capped."""
+        tracker = TokenTracker()
+        tracker.reset()
+
+        callback = TokenTrackingCallback(
+            agent_name="test_agent",
+            tracker=tracker,
+            output_token_cap=1000,
+        )
+        llm_result = LLMResult(
+            generations=[],
+            llm_output={
+                "model_name": "gemini-2.5-flash",
+                "usage_metadata": {"input_tokens": 1000, "output_tokens": 500},
+            },
+        )
+
+        with patch("src.token_tracker.logger.info") as mock_info:
+            callback.on_llm_end(llm_result)
+
+        budget_logs = [
+            call
+            for call in mock_info.call_args_list
+            if call.args and call.args[0] == "llm_output_budget_usage"
+        ]
+        assert len(budget_logs) == 1
+        assert budget_logs[0].kwargs["configured_output_cap"] == 1000
+        assert budget_logs[0].kwargs["completion_tokens"] == 500
+        assert budget_logs[0].kwargs["utilization_ratio"] == 0.5
 
     def test_callback_with_custom_tracker(self):
         """Test creating callback with custom tracker instance."""

--- a/tests/agents/test_artifact_fallbacks.py
+++ b/tests/agents/test_artifact_fallbacks.py
@@ -9,20 +9,19 @@ from src.validators.red_flag_detector import RedFlagDetector
 
 class TestArtifactFallbacks:
     @pytest.mark.asyncio
-    @patch("src.agents.consultant_nodes.create_react_agent")
     @patch("src.prompts.get_prompt")
     async def test_legal_counsel_failure_preserves_conservative_fallback(
-        self, mock_get_prompt, mock_create_react_agent
+        self, mock_get_prompt
     ):
         mock_get_prompt.return_value = SimpleNamespace(system_message="legal prompt")
-        mock_create_react_agent.return_value = SimpleNamespace(
-            ainvoke=AsyncMock(side_effect=RuntimeError("dns failure"))
+
+        # The manual loop invokes llm.ainvoke directly — mock the LLM to fail.
+        mock_llm = SimpleNamespace(
+            ainvoke=AsyncMock(side_effect=RuntimeError("dns failure")),
+            model_name="gemini-3-flash-preview",
         )
 
-        node = create_legal_counsel_node(
-            SimpleNamespace(model_name="gemini-3-flash-preview"),
-            [],
-        )
+        node = create_legal_counsel_node(mock_llm, [])
         result = await node(
             {
                 "company_of_interest": "TOTL.JK",
@@ -42,19 +41,22 @@ class TestArtifactFallbacks:
         assert "Legal counsel unavailable" in risks["pfic_evidence"]
 
     @pytest.mark.asyncio
-    @patch("src.agents.consultant_nodes.create_react_agent")
     @patch("src.prompts.get_prompt")
     async def test_auditor_context_limit_preserves_graceful_report(
-        self, mock_get_prompt, mock_create_react_agent
+        self, mock_get_prompt
     ):
         mock_get_prompt.return_value = SimpleNamespace(system_message="auditor prompt")
-        mock_create_react_agent.return_value = SimpleNamespace(
+
+        # The manual loop invokes llm.ainvoke directly — mock the LLM to raise a
+        # context-limit error so the graceful fallback path is exercised.
+        mock_llm = SimpleNamespace(
             ainvoke=AsyncMock(
                 side_effect=RuntimeError("maximum context length exceeded")
-            )
+            ),
+            model_name="gpt-4o",
         )
 
-        node = create_auditor_node(SimpleNamespace(model_name="gpt-4o"), [])
+        node = create_auditor_node(mock_llm, [])
         result = await node(
             {
                 "company_of_interest": "TOTL.JK",
@@ -71,3 +73,39 @@ class TestArtifactFallbacks:
         assert status["error_kind"] == "application_error"
         assert "CONTEXT_LIMIT_EXCEEDED" in result["auditor_report"]
         assert "FORENSIC_DATA_BLOCK" in result["auditor_report"]
+
+    @pytest.mark.asyncio
+    @patch("src.prompts.get_prompt")
+    async def test_auditor_param_error_retries_with_fallback_llm(self, mock_get_prompt):
+        mock_get_prompt.return_value = SimpleNamespace(system_message="auditor prompt")
+
+        initial_llm = SimpleNamespace(model_name="gpt-4o")
+        fallback_llm = SimpleNamespace(model_name="gpt-4o")
+        final_response = SimpleNamespace(content="retry success", tool_calls=None)
+        invoke_mock = AsyncMock(
+            side_effect=[RuntimeError("Unsupported value"), final_response]
+        )
+
+        with patch(
+            "src.agents.runtime.invoke_with_rate_limit_handling", new=invoke_mock
+        ):
+            with patch(
+                "langchain_openai.ChatOpenAI", return_value=fallback_llm
+            ) as mock_chat:
+                node = create_auditor_node(initial_llm, [])
+                result = await node(
+                    {
+                        "company_of_interest": "TOTL.JK",
+                        "company_name": "Total Indonesia",
+                        "company_name_resolved": True,
+                    },
+                    {},
+                )
+
+        status = result["artifact_statuses"]["auditor_report"]
+
+        assert status["complete"] is True
+        assert status["ok"] is True
+        assert result["auditor_report"] == "retry success"
+        assert invoke_mock.await_count == 2
+        mock_chat.assert_called_once()

--- a/tests/agents/test_output_validation.py
+++ b/tests/agents/test_output_validation.py
@@ -1,0 +1,96 @@
+from unittest.mock import Mock
+
+from src.agents.output_validation import (
+    extract_completion_tokens,
+    get_configured_output_cap,
+    should_fail_closed,
+    validate_required_output,
+)
+
+
+def test_validate_required_output_accepts_parseable_data_block():
+    content = """
+### --- START DATA_BLOCK ---
+RAW_HEALTH_SCORE: 7/12
+ADJUSTED_HEALTH_SCORE: 58%
+### --- END DATA_BLOCK ---
+"""
+
+    validation = validate_required_output("fundamentals_analyst", content)
+
+    assert validation["ok"] is True
+    assert validation["missing"] == []
+
+
+def test_validate_required_output_detects_missing_pm_sections():
+    content = """
+### PORTFOLIO MANAGER VERDICT: BUY
+### THESIS COMPLIANCE SUMMARY
+"""
+
+    validation = validate_required_output("portfolio_manager", content)
+
+    assert validation["ok"] is False
+    assert "execution_section" in validation["missing"]
+
+
+def test_validate_required_output_accepts_consultant_structure():
+    content = """
+### CONSULTANT REVIEW: APPROVED
+### FINAL CONSULTANT VERDICT
+Overall Assessment: APPROVED
+"""
+
+    validation = validate_required_output("consultant", content)
+
+    assert validation["ok"] is True
+
+
+def test_extract_completion_tokens_tolerates_mock_usage_metadata():
+    response = Mock()
+    response.usage_metadata = Mock()
+    response.response_metadata = {}
+
+    assert extract_completion_tokens(response) == 0
+
+
+def test_get_configured_output_cap_ignores_non_numeric_mock_attrs():
+    runnable = Mock()
+
+    assert get_configured_output_cap(runnable) is None
+
+
+def test_consultant_validation_does_not_fail_closed_on_short_nontruncated_output():
+    validation = {
+        "ok": False,
+        "checks": [("final_verdict", False)],
+        "missing": ["final_verdict"],
+    }
+
+    assert (
+        should_fail_closed(
+            "consultant",
+            validation=validation,
+            truncated=False,
+            content="CONSULTANT REVIEW: APPROVED",
+        )
+        is False
+    )
+
+
+def test_portfolio_manager_validation_fails_closed_when_required_structure_missing():
+    validation = {
+        "ok": False,
+        "checks": [("execution_section", False)],
+        "missing": ["execution_section"],
+    }
+
+    assert (
+        should_fail_closed(
+            "portfolio_manager",
+            validation=validation,
+            truncated=False,
+            content="### PORTFOLIO MANAGER VERDICT: BUY",
+        )
+        is True
+    )

--- a/tests/financial/test_data_integrity.py
+++ b/tests/financial/test_data_integrity.py
@@ -10,6 +10,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.data.fetcher import SmartMarketDataFetcher
+from src.ticker_policy import (
+    allows_search_resolution,
+    is_safe_symbol_crossmatch_base,
+    normalize_exchange_specific_base,
+    same_exchange,
+    split_ticker,
+)
 
 
 @pytest.fixture
@@ -66,6 +73,96 @@ class TestTickerResolution:
         resolved = await fetcher._resolve_ticker_via_search("AAPL")
         assert resolved is None
         assert not fetcher.tavily_client.search.called
+
+    @pytest.mark.asyncio
+    async def test_resolve_ticker_tokyo_disabled(self, fetcher):
+        fetcher.tavily_client = MagicMock()
+
+        resolved = await fetcher._resolve_ticker_via_search("262A.T")
+        assert resolved is None
+        assert not fetcher.tavily_client.search.called
+
+    @pytest.mark.asyncio
+    async def test_resolve_ticker_taiwan_requires_exact_suffix(self, fetcher):
+        fetcher.tavily_client = MagicMock()
+        fetcher.tavily_client.search = MagicMock(
+            return_value={
+                "results": [
+                    {
+                        "title": "Cross-listed examples",
+                        "content": "2628.HK 2628.TW 2628.T appear together; correct TW code is 2628.TW",
+                    }
+                ]
+            }
+        )
+
+        resolved = await fetcher._resolve_ticker_via_search("FOO.TW")
+        assert resolved == "2628.TW"
+
+    @pytest.mark.asyncio
+    async def test_resolve_ticker_two_requires_exact_suffix(self, fetcher):
+        fetcher.tavily_client = MagicMock()
+        fetcher.tavily_client.search = MagicMock(
+            return_value={
+                "results": [
+                    {
+                        "title": "Cross-listed OTC examples",
+                        "content": "1264.TWO and 1264.TW are different listings; exact OTC code is 1264.TWO",
+                    }
+                ]
+            }
+        )
+
+        resolved = await fetcher._resolve_ticker_via_search("FOO.TWO")
+        assert resolved == "1264.TWO"
+
+    @pytest.mark.asyncio
+    async def test_resolve_ticker_does_not_cross_exchange_on_shared_numeric(
+        self, fetcher
+    ):
+        fetcher.tavily_client = MagicMock()
+        fetcher.tavily_client.search = MagicMock(
+            return_value={
+                "results": [
+                    {
+                        "title": "Shared numeric codes",
+                        "content": "2628.HK appears here, but 2628.T is a different Japanese listing.",
+                    }
+                ]
+            }
+        )
+
+        resolved = await fetcher._resolve_ticker_via_search("FOO.TW")
+        assert resolved is None
+
+
+class TestTickerPolicy:
+    def test_split_ticker_preserves_exchange(self):
+        assert split_ticker("262A.T") == ("262A", ".T")
+        assert split_ticker("0005.HK") == ("0005", ".HK")
+
+    def test_same_exchange_requires_identical_suffix(self):
+        assert same_exchange("2628.HK", "0700.HK") is True
+        assert same_exchange("2628.HK", "2628.TW") is False
+        assert same_exchange("2628.T", "2628.TW") is False
+        assert same_exchange("1264.TWO", "1264.TW") is False
+
+    def test_crossmatch_safe_only_for_non_numeric_bases(self):
+        assert is_safe_symbol_crossmatch_base("262A") is True
+        assert is_safe_symbol_crossmatch_base("CEK") is True
+        assert is_safe_symbol_crossmatch_base("2628") is False
+
+    def test_exchange_specific_normalization_only_pads_hk(self):
+        assert normalize_exchange_specific_base("5", ".HK") == "0005"
+        assert normalize_exchange_specific_base("262A", ".T") == "262A"
+        assert normalize_exchange_specific_base("2330", ".TW") == "2330"
+
+    def test_search_resolution_policy_is_exchange_specific(self):
+        assert allows_search_resolution("TENCENT.HK") is True
+        assert allows_search_resolution("PADINI.KL") is True
+        assert allows_search_resolution("2330.TW") is True
+        assert allows_search_resolution("1264.TWO") is True
+        assert allows_search_resolution("262A.T") is False
 
 
 class TestScalingCorrection:

--- a/tests/financial/test_filings.py
+++ b/tests/financial/test_filings.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.data.filings.base import FilingFetcher, FilingResult
+from src.data.filings.edinet_fetcher import _extract_ticker_base
 from src.data.filings.registry import FilingRegistry
 
 # ============================================================================
@@ -217,7 +218,6 @@ class TestFilingRegistry:
         reg = FilingRegistry()
         fetcher = _MockFetcher(["T"], "EDINET", available=False)
         reg.register(fetcher)
-
         assert reg.get_fetcher("2767.T") is None
 
     def test_multiple_suffixes_registered(self):
@@ -251,22 +251,11 @@ class TestFilingRegistry:
         """fetch() should catch exceptions and return None."""
         reg = FilingRegistry()
 
-        class _ErrorFetcher(FilingFetcher):
-            @property
-            def supported_suffixes(self):
-                return ["T"]
-
-            @property
-            def source_name(self):
-                return "BROKEN"
-
-            def is_available(self):
-                return True
-
+        class BrokenFetcher(_MockFetcher):
             async def get_filing_data(self, ticker):
-                raise RuntimeError("API down")
+                raise RuntimeError("boom")
 
-        reg.register(_ErrorFetcher())
+        reg.register(BrokenFetcher(["T"], "BROKEN"))
         result = await reg.fetch("2767.T")
         assert result is None
 
@@ -278,6 +267,14 @@ class TestFilingRegistry:
 
         assert "T" in reg.available_suffixes
         assert "KS" not in reg.available_suffixes
+
+
+class TestEdinetTickerBaseExtraction:
+    def test_alphanumeric_tokyo_base_preserved(self):
+        assert _extract_ticker_base("262A.T") == "262A"
+
+    def test_numeric_tokyo_base_preserved(self):
+        assert _extract_ticker_base("2767.T") == "2767"
 
 
 # ============================================================================

--- a/tests/ibkr/test_format_report.py
+++ b/tests/ibkr/test_format_report.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from scripts.portfolio_manager import _compute_dip_score, format_report
+from unittest.mock import patch
+
+from scripts.portfolio_manager import (
+    _analysis_command,
+    _compute_dip_score,
+    _portfolio_manager_command,
+    format_report,
+)
 from src.ibkr.models import (
     AnalysisRecord,
     NormalizedPosition,
@@ -67,6 +74,22 @@ def _panic_items() -> list[ReconciliationItem]:
         )
     )
     return items
+
+
+class TestRuntimeCommandHints:
+    def test_analysis_command_uses_python_in_container(self, monkeypatch):
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.setenv("INVESTMENT_AGENT_CONTAINER", "1")
+        assert _analysis_command("7203.T") == "python -m src.main --ticker 7203.T"
+
+    def test_portfolio_manager_command_falls_back_to_poetry_on_host(self, monkeypatch):
+        monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+        monkeypatch.delenv("INVESTMENT_AGENT_CONTAINER", raising=False)
+        with patch("scripts.portfolio_manager.Path.exists", return_value=False):
+            assert (
+                _portfolio_manager_command("--recommend")
+                == "poetry run python scripts/portfolio_manager.py --recommend"
+            )
 
 
 class TestFormatReportPanicDay:

--- a/tests/ibkr/test_reconciler.py
+++ b/tests/ibkr/test_reconciler.py
@@ -219,6 +219,78 @@ class TestCheckStaleness:
         is_stale, _ = check_staleness(analysis, structural_macro_events=[event])
         assert is_stale is False
 
+
+class TestAlphaBaseFallback:
+    def test_alphanumeric_base_matches_suffixed_analysis(self):
+        pos = _make_position(ticker="262A.T", currency="JPY")
+        pos = NormalizedPosition(
+            conid=pos.conid,
+            ticker=Ticker.from_ibkr("262A", "UNKNOWN", "JPY"),
+            quantity=pos.quantity,
+            avg_cost_local=pos.avg_cost_local,
+            market_value_usd=pos.market_value_usd,
+            currency=pos.currency,
+            current_price_local=pos.current_price_local,
+        )
+        analyses = {"262A.T": _make_analysis(ticker="262A.T")}
+
+        items = reconcile(
+            positions=[pos], analyses=analyses, portfolio=_make_portfolio()
+        )
+
+        assert len(items) == 1
+        assert items[0].ticker.yf == "262A.T"
+
+    def test_suffixed_analysis_wins_over_bare_for_alphanumeric_base(self):
+        pos = NormalizedPosition(
+            conid=123456,
+            ticker=Ticker.from_ibkr("CEK", "UNKNOWN", "EUR"),
+            quantity=100,
+            avg_cost_local=10,
+            market_value_usd=1000,
+            currency="EUR",
+            current_price_local=10,
+        )
+        analyses = {
+            "CEK": _make_analysis(ticker="CEK", verdict="HOLD"),
+            "CEK.DE": _make_analysis(ticker="CEK.DE", verdict="BUY"),
+        }
+
+        items = reconcile(
+            positions=[pos], analyses=analyses, portfolio=_make_portfolio()
+        )
+
+        assert len(items) == 1
+        assert items[0].ticker.yf == "CEK.DE"
+
+    def test_numeric_base_does_not_crossmatch_across_exchanges(self):
+        pos = NormalizedPosition(
+            conid=123456,
+            ticker=Ticker.from_ibkr("2628", "UNKNOWN", ""),
+            quantity=100,
+            avg_cost_local=10,
+            market_value_usd=1000,
+            currency="USD",
+            current_price_local=10,
+        )
+        analyses = {
+            "2628.HK": _make_analysis(
+                ticker="2628.HK", verdict="BUY", current_price=10
+            ),
+            "2628.TW": _make_analysis(
+                ticker="2628.TW", verdict="BUY", current_price=10
+            ),
+            "2628.T": _make_analysis(ticker="2628.T", verdict="BUY", current_price=10),
+        }
+
+        items = reconcile(
+            positions=[pos], analyses=analyses, portfolio=_make_portfolio()
+        )
+
+        assert len(items) == 1
+        assert items[0].action == "REVIEW"
+        assert "no evaluator analysis" in items[0].reason.lower()
+
     def test_regional_structural_event_invalidates_matching_exchange(self):
         """STRUCTURAL event scoped to .T invalidates a .T ticker."""
         from src.memory import MacroEvent

--- a/tests/ibkr/test_ticker.py
+++ b/tests/ibkr/test_ticker.py
@@ -133,6 +133,12 @@ class TestTickerFromYf:
         assert t.suffix == ".T"
         assert t.yf == "7203.T"
 
+    def test_japan_alphanumeric_suffix(self):
+        t = Ticker.from_yf("262A.T")
+        assert t.symbol == "262A"
+        assert t.suffix == ".T"
+        assert t.yf == "262A.T"
+
     def test_hong_kong_suffix(self):
         t = Ticker.from_yf("0005.HK")
         assert t.symbol == "5"  # zero-padding stripped from symbol

--- a/tests/scripts/test_run_pipeline.py
+++ b/tests/scripts/test_run_pipeline.py
@@ -17,7 +17,7 @@ class TestVerdictExtraction:
       # TICKER: DO_NOT_INITIATE
     """
 
-    HEADER_PATTERN = re.compile(r"^# .+: (?P<verdict>[A-Z_]+)$", re.MULTILINE)
+    HEADER_PATTERN = re.compile(r"^# .+: (?P<verdict>[^\r\n]+)$", re.MULTILINE)
 
     @classmethod
     def _extract_verdict(cls, content: str) -> str | None:
@@ -37,12 +37,12 @@ class TestVerdictExtraction:
         assert self._extract_verdict(content) == "HOLD"
 
     def test_do_not_initiate_detected(self):
-        content = "# X.Y (Foo Corp): DO_NOT_INITIATE\n"
-        assert self._extract_verdict(content) == "DO_NOT_INITIATE"
+        content = "# X.Y (Foo Corp): DO NOT INITIATE\n"
+        assert self._extract_verdict(content) == "DO NOT INITIATE"
 
     def test_no_company_name_header_detected(self):
-        content = "# 262A.T: DO_NOT_INITIATE\n"
-        assert self._extract_verdict(content) == "DO_NOT_INITIATE"
+        content = "# 262A.T: DO NOT INITIATE\n"
+        assert self._extract_verdict(content) == "DO NOT INITIATE"
 
     def test_exchange_qualified_numeric_headers_detected(self):
         assert self._extract_verdict("# 2628.HK (Foo): BUY\n") == "BUY"
@@ -86,6 +86,10 @@ class TestVerdictExtraction:
         content = "# X.Y (Foo): BUY_SOMETHING\n"
         assert self._extract_verdict(content) == "BUY_SOMETHING"
 
+    def test_verdict_with_spaces_detected(self):
+        content = "# 0142.HK (First Pacific Company Limited): DO NOT INITIATE\n"
+        assert self._extract_verdict(content) == "DO NOT INITIATE"
+
 
 # ============================================================
 # TestTickerToDash — filename convention
@@ -120,6 +124,91 @@ class TestTickerToDash:
         assert self._ticker_to_dash("BRK_B.TO") == "BRK-B-TO"
 
 
+class TestRunDateDerivation:
+    DATE_RE = re.compile(r"([0-9]{4}-[0-9]{2}-[0-9]{2})")
+
+    @classmethod
+    def _extract_date(cls, path: str) -> str | None:
+        match = cls.DATE_RE.search(Path(path).name)
+        return match.group(1) if match else None
+
+    @classmethod
+    def _derive_run_date(
+        cls,
+        today: str,
+        *,
+        skip_scrape: str = "",
+        buys_file: str = "",
+        run_date: str = "",
+    ) -> str:
+        if run_date:
+            return run_date
+        if buys_file:
+            extracted = cls._extract_date(buys_file)
+            if extracted:
+                return extracted
+        if skip_scrape:
+            extracted = cls._extract_date(skip_scrape)
+            if extracted:
+                return extracted
+        return today
+
+    def test_skip_scrape_date_drives_stage1_resume(self):
+        assert (
+            self._derive_run_date(
+                "2026-03-20", skip_scrape="scratch/gems_2026-03-19.txt"
+            )
+            == "2026-03-19"
+        )
+
+    def test_buys_file_date_drives_stage2_resume(self):
+        assert (
+            self._derive_run_date("2026-03-20", buys_file="scratch/buys_2026-03-18.txt")
+            == "2026-03-18"
+        )
+
+    def test_explicit_run_date_wins(self):
+        assert (
+            self._derive_run_date(
+                "2026-03-20",
+                skip_scrape="scratch/gems_2026-03-19.txt",
+                buys_file="scratch/buys_2026-03-18.txt",
+                run_date="2026-03-17",
+            )
+            == "2026-03-17"
+        )
+
+    @staticmethod
+    def _detect_stage1_resume_date(
+        inferred_date: str,
+        today: str,
+        completed_counts: dict[str, int],
+    ) -> str:
+        inferred_count = completed_counts.get(inferred_date, 0)
+        today_count = completed_counts.get(today, 0)
+        return today if today_count > inferred_count else inferred_date
+
+    def test_stage1_prefers_today_when_more_outputs_exist(self):
+        assert (
+            self._detect_stage1_resume_date(
+                "2026-03-19",
+                "2026-03-20",
+                {"2026-03-19": 6, "2026-03-20": 149},
+            )
+            == "2026-03-20"
+        )
+
+    def test_stage1_keeps_inferred_date_when_it_has_more_outputs(self):
+        assert (
+            self._detect_stage1_resume_date(
+                "2026-03-19",
+                "2026-03-20",
+                {"2026-03-19": 149, "2026-03-20": 6},
+            )
+            == "2026-03-19"
+        )
+
+
 # ============================================================
 # TestResumability — skip logic
 # ============================================================
@@ -146,7 +235,7 @@ class TestResumability:
         """
         if not force and outfile.is_file():
             content = outfile.read_text()
-            if re.search(r"^# .+: [A-Z_]+$", content, re.MULTILINE):
+            if re.search(r"^# .+: .+$", content, re.MULTILINE):
                 return "SKIP"
         return "PROCESS"
 
@@ -187,14 +276,14 @@ class TestResumability:
 
     def test_do_not_initiate_also_skipped(self, tmp_path):
         outfile = tmp_path / "report.md"
-        outfile.write_text("# X.Y (Foo Corp): DO_NOT_INITIATE\n")
+        outfile.write_text("# X.Y (Foo Corp): DO NOT INITIATE\n")
 
         result = self._run_skip_check(outfile, force=False)
         assert result == "SKIP"
 
     def test_no_company_name_header_also_skipped(self, tmp_path):
         outfile = tmp_path / "report.md"
-        outfile.write_text("# 262A.T: DO_NOT_INITIATE\n")
+        outfile.write_text("# 262A.T: DO NOT INITIATE\n")
 
         result = self._run_skip_check(outfile, force=False)
         assert result == "SKIP"

--- a/tests/scripts/test_run_pipeline.py
+++ b/tests/scripts/test_run_pipeline.py
@@ -12,37 +12,42 @@ import pytest
 class TestVerdictExtraction:
     """Test the verdict extraction patterns used by run_pipeline.sh.
 
-    The shell script uses grep patterns like:
-      grep -qE '^# .*\\): BUY$' "$OUTFILE"
-    to determine the verdict from the markdown title line.
+    The shell script parses headers in either of these forms:
+      # TICKER (Company Name): BUY
+      # TICKER: DO_NOT_INITIATE
     """
 
-    # The same regex patterns used in run_pipeline.sh
-    BUY_PATTERN = re.compile(r"^# .*\): BUY$", re.MULTILINE)
-    SELL_PATTERN = re.compile(r"^# .*\): SELL", re.MULTILINE)
-    HOLD_PATTERN = re.compile(r"^# .*\): HOLD", re.MULTILINE)
-    DNI_PATTERN = re.compile(r"^# .*\): DO_NOT_INITIATE", re.MULTILINE)
-    # Generic "has verdict" pattern (used for skip logic)
-    VERDICT_PATTERN = re.compile(r"^# .*\): ", re.MULTILINE)
+    HEADER_PATTERN = re.compile(r"^# .+: (?P<verdict>[A-Z_]+)$", re.MULTILINE)
+
+    @classmethod
+    def _extract_verdict(cls, content: str) -> str | None:
+        match = cls.HEADER_PATTERN.search(content)
+        return match.group("verdict") if match else None
 
     def test_buy_detected(self, tmp_path):
         content = "# 8002.T (Marubeni Corporation): BUY\n"
-        assert self.BUY_PATTERN.search(content) is not None
+        assert self._extract_verdict(content) == "BUY"
 
     def test_sell_detected(self, tmp_path):
         content = "# UNTR.JK (PT United Tractors Tbk): SELL\n"
-        assert self.BUY_PATTERN.search(content) is None
-        assert self.SELL_PATTERN.search(content) is not None
+        assert self._extract_verdict(content) == "SELL"
 
     def test_hold_detected(self):
         content = "# 7740.T (Tamron Co.,Ltd.): HOLD\n"
-        assert self.BUY_PATTERN.search(content) is None
-        assert self.HOLD_PATTERN.search(content) is not None
+        assert self._extract_verdict(content) == "HOLD"
 
     def test_do_not_initiate_detected(self):
         content = "# X.Y (Foo Corp): DO_NOT_INITIATE\n"
-        assert self.BUY_PATTERN.search(content) is None
-        assert self.DNI_PATTERN.search(content) is not None
+        assert self._extract_verdict(content) == "DO_NOT_INITIATE"
+
+    def test_no_company_name_header_detected(self):
+        content = "# 262A.T: DO_NOT_INITIATE\n"
+        assert self._extract_verdict(content) == "DO_NOT_INITIATE"
+
+    def test_exchange_qualified_numeric_headers_detected(self):
+        assert self._extract_verdict("# 2628.HK (Foo): BUY\n") == "BUY"
+        assert self._extract_verdict("# 2628.TW (Bar): HOLD\n") == "HOLD"
+        assert self._extract_verdict("# 2628.T (Baz): SELL\n") == "SELL"
 
     def test_verdict_at_line_10(self):
         """Report has preamble lines before the verdict title."""
@@ -59,28 +64,27 @@ class TestVerdictExtraction:
             "# 8002.T (Marubeni Corporation): BUY",
         ]
         content = "\n".join(lines) + "\n"
-        assert self.BUY_PATTERN.search(content) is not None
+        assert self._extract_verdict(content) == "BUY"
 
     def test_commas_in_company_name(self):
         """Company names with commas and periods should still match."""
         content = "# 7740.T (Tamron Co.,Ltd.): HOLD\n"
-        assert self.VERDICT_PATTERN.search(content) is not None
-        assert self.HOLD_PATTERN.search(content) is not None
+        assert self._extract_verdict(content) == "HOLD"
 
     def test_parentheses_in_company_name(self):
         """Nested parentheses shouldn't break the match."""
         content = "# 2330.TW (Taiwan Semiconductor (TSMC)): BUY\n"
-        assert self.BUY_PATTERN.search(content) is not None
+        assert self._extract_verdict(content) == "BUY"
 
     def test_no_verdict_line(self):
         """File without verdict line should not match."""
         content = "Some random content\nNo verdict here\n"
-        assert self.VERDICT_PATTERN.search(content) is None
+        assert self._extract_verdict(content) is None
 
     def test_buy_must_be_exact_end(self):
         """BUY pattern requires exact match at end of line (no trailing text)."""
         content = "# X.Y (Foo): BUY_SOMETHING\n"
-        assert self.BUY_PATTERN.search(content) is None
+        assert self._extract_verdict(content) == "BUY_SOMETHING"
 
 
 # ============================================================
@@ -132,8 +136,7 @@ class TestResumability:
     def _run_skip_check(outfile: Path, force: bool = False) -> str:
         """Pure-Python reimplementation of the skip logic from run_pipeline.sh.
 
-        The shell script checks:
-          if ! $FORCE && [[ -f "$OUTFILE" ]] && grep -qE '^# .*\\): ' "$OUTFILE"
+        The shell script checks whether the report has a parseable verdict header.
 
         Returns "SKIP" or "PROCESS".
 
@@ -143,7 +146,7 @@ class TestResumability:
         """
         if not force and outfile.is_file():
             content = outfile.read_text()
-            if re.search(r"^# .*\): ", content, re.MULTILINE):
+            if re.search(r"^# .+: [A-Z_]+$", content, re.MULTILINE):
                 return "SKIP"
         return "PROCESS"
 
@@ -185,6 +188,13 @@ class TestResumability:
     def test_do_not_initiate_also_skipped(self, tmp_path):
         outfile = tmp_path / "report.md"
         outfile.write_text("# X.Y (Foo Corp): DO_NOT_INITIATE\n")
+
+        result = self._run_skip_check(outfile, force=False)
+        assert result == "SKIP"
+
+    def test_no_company_name_header_also_skipped(self, tmp_path):
+        outfile = tmp_path / "report.md"
+        outfile.write_text("# 262A.T: DO_NOT_INITIATE\n")
 
         result = self._run_skip_check(outfile, force=False)
         assert result == "SKIP"

--- a/tests/test_content_ingress_coverage.py
+++ b/tests/test_content_ingress_coverage.py
@@ -1,0 +1,222 @@
+"""Structural tests that prevent future content-inspection bypasses.
+
+These tests are grep-based and enforce the coverage invariant: every
+external-content ingress path must route through INSPECTION_SERVICE before
+returning content to callers.  They fail fast if someone removes inspection
+calls or adds new bare ingress paths without wiring inspection.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+SRC_ROOT = Path(__file__).parent.parent / "src"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _src(rel: str) -> Path:
+    return SRC_ROOT / rel
+
+
+# ---------------------------------------------------------------------------
+# 1. No bare create_react_agent in agent node files
+#    (must use TOOL_SERVICE loops instead)
+# ---------------------------------------------------------------------------
+
+
+def test_no_bare_create_react_agent_in_consultant_nodes():
+    """Legal Counsel and Auditor must NOT use create_react_agent (bypasses TOOL_SERVICE)."""
+    src = _read(_src("agents/consultant_nodes.py"))
+    # Allow the import comment to remain but not any actual calls
+    calls = re.findall(r"\bcreate_react_agent\s*\(", src)
+    assert calls == [], (
+        f"consultant_nodes.py still contains create_react_agent() calls: {calls}. "
+        "These bypass TOOL_SERVICE and content inspection hooks."
+    )
+
+
+def test_create_react_agent_not_imported_in_consultant_nodes():
+    """create_react_agent import should be removed once the loops are in place."""
+    src = _read(_src("agents/consultant_nodes.py"))
+    assert "from langgraph.prebuilt import create_react_agent" not in src, (
+        "create_react_agent is still imported in consultant_nodes.py — "
+        "remove the import once the manual loops are in place."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Direct-ingress callsites have inspection calls
+# ---------------------------------------------------------------------------
+
+
+def test_tavily_utils_has_inspection():
+    """tavily_search_with_timeout must call INSPECTION_SERVICE.check before returning."""
+    src = _read(_src("tavily_utils.py"))
+    assert "INSPECTION_SERVICE.check" in src, (
+        "tavily_utils.py: tavily_search_with_timeout must call "
+        "INSPECTION_SERVICE.check() before returning results."
+    )
+
+
+def test_editor_tools_fetch_reference_has_inspection():
+    """fetch_reference_content must call INSPECTION_SERVICE.check on fetched content."""
+    src = _read(_src("editor_tools.py"))
+    assert "INSPECTION_SERVICE.check" in src, (
+        "editor_tools.py: fetch_reference_content must call "
+        "INSPECTION_SERVICE.check() before returning fetched content."
+    )
+
+
+def test_editor_tools_search_claim_uses_inspected_tavily_helper():
+    """search_claim must rely on tavily_search_with_timeout for inspected results."""
+    src = _read(_src("editor_tools.py"))
+    assert "tavily_search_with_timeout" in src, (
+        "editor_tools.py: search_claim must call tavily_search_with_timeout(), "
+        "which inspects Tavily output before returning it."
+    )
+
+
+def test_news_stocktwits_has_inspection():
+    """StockTwits message content must be inspected before inclusion in output."""
+    src = _read(_src("tools/news.py"))
+    assert "INSPECTION_SERVICE.check" in src, (
+        "tools/news.py: get_social_media_sentiment must call "
+        "INSPECTION_SERVICE.check() on StockTwits message content."
+    )
+
+
+def test_fetcher_tavily_gaps_has_inspection():
+    """_fetch_tavily_gaps must call INSPECTION_SERVICE.check before extracting metrics."""
+    src = _read(_src("data/fetcher.py"))
+    assert "INSPECTION_SERVICE.check" in src, (
+        "data/fetcher.py: _fetch_tavily_gaps must call "
+        "INSPECTION_SERVICE.check() before passing web text to pattern_extractor."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. TOOL_SERVICE used at legal_counsel and auditor sources
+# ---------------------------------------------------------------------------
+
+
+def test_legal_counsel_uses_tool_service():
+    """Legal Counsel tool calls must route through TOOL_SERVICE."""
+    src = _read(_src("agents/consultant_nodes.py"))
+    # Verify TOOL_SERVICE.execute is called with source="legal_counsel"
+    assert 'source="legal_counsel"' in src, (
+        "consultant_nodes.py: Legal Counsel tool calls must pass "
+        'source="legal_counsel" to TOOL_SERVICE.execute().'
+    )
+
+
+def test_auditor_uses_tool_service():
+    """Auditor tool calls must route through TOOL_SERVICE."""
+    src = _read(_src("agents/consultant_nodes.py"))
+    assert 'source="auditor"' in src, (
+        "consultant_nodes.py: Auditor tool calls must pass "
+        'source="auditor" to TOOL_SERVICE.execute().'
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. ToolSource literal includes legal_counsel and auditor
+# ---------------------------------------------------------------------------
+
+
+def test_tool_source_includes_legal_counsel_and_auditor():
+    """ToolSource TypeAlias must enumerate legal_counsel and auditor."""
+    src = _read(_src("tooling/runtime.py"))
+    assert (
+        '"legal_counsel"' in src
+    ), "tooling/runtime.py: ToolSource must include 'legal_counsel'."
+    assert '"auditor"' in src, "tooling/runtime.py: ToolSource must include 'auditor'."
+
+
+# ---------------------------------------------------------------------------
+# 5. Config includes inspection settings
+# ---------------------------------------------------------------------------
+
+
+def test_config_has_inspection_settings():
+    src = _read(_src("config.py"))
+    assert (
+        "untrusted_content_inspection_enabled" in src
+    ), "config.py: missing untrusted_content_inspection_enabled setting."
+    assert (
+        "untrusted_content_inspection_mode" in src
+    ), "config.py: missing untrusted_content_inspection_mode setting."
+    assert (
+        "untrusted_content_fail_policy" in src
+    ), "config.py: missing untrusted_content_fail_policy setting."
+
+
+# ---------------------------------------------------------------------------
+# 6. Main.py wires inspection independently of logging
+# ---------------------------------------------------------------------------
+
+
+def test_main_has_configure_content_inspection():
+    src = _read(_src("main.py"))
+    assert (
+        "configure_content_inspection_from_config" in src
+    ), "main.py: configure_content_inspection_from_config() must be called at startup."
+    # Must not be gated inside configure_cli_logging
+    # Find the configure_cli_logging function body and ensure inspection is NOT there
+    # (it should be in _setup_runtime, independently)
+    cli_logging_match = re.search(
+        r"def configure_cli_logging\(.*?\)\s*->.*?:\n(.*?)(?=\ndef |\Z)",
+        src,
+        re.DOTALL,
+    )
+    assert (
+        cli_logging_match is not None
+    ), "Could not locate configure_cli_logging() body."
+    cli_logging_body = cli_logging_match.group(1)
+    assert "configure_content_inspection_from_config" not in cli_logging_body, (
+        "configure_content_inspection_from_config must NOT be inside "
+        "configure_cli_logging — inspection is independent of logging verbosity."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. INSPECTION_SERVICE singleton exists
+# ---------------------------------------------------------------------------
+
+
+def test_inspection_service_singleton_exists():
+    src = _read(_src("tooling/inspection_service.py"))
+    assert (
+        "INSPECTION_SERVICE = InspectionService()" in src
+    ), "tooling/inspection_service.py: INSPECTION_SERVICE singleton must be defined."
+
+
+# ---------------------------------------------------------------------------
+# 8. InspectionEnvelope and SourceKind are importable from src.tooling
+# ---------------------------------------------------------------------------
+
+
+def test_inspection_types_exported_from_tooling():
+    from src.tooling import (  # noqa: F401
+        INSPECTION_SERVICE,
+        CompositeInspector,
+        ContentInspectionHook,
+        ContentInspector,
+        InspectionDecision,
+        InspectionEnvelope,
+        InspectionService,
+        NullInspector,
+        SourceKind,
+        configure_content_inspection,
+    )

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -167,6 +167,89 @@ class TestToolAuditLogging:
         finally:
             configure_tool_audit_logging(False)
 
+    def test_configure_tool_audit_logging_preserves_content_inspection_hook(self):
+        from src.main import configure_tool_audit_logging
+        from src.tooling.inspection_hook import ContentInspectionHook
+        from src.tooling.runtime import TOOL_SERVICE
+
+        TOOL_SERVICE.set_hooks([ContentInspectionHook()])
+        try:
+            configure_tool_audit_logging(True)
+            hook_types = [type(h).__name__ for h in TOOL_SERVICE.hooks]
+            assert "LoggingToolAuditHook" in hook_types
+            assert "ContentInspectionHook" in hook_types
+
+            configure_tool_audit_logging(False)
+            hook_types = [type(h).__name__ for h in TOOL_SERVICE.hooks]
+            assert "LoggingToolAuditHook" not in hook_types
+            assert "ContentInspectionHook" in hook_types
+        finally:
+            TOOL_SERVICE.clear_hooks()
+
+    def test_configure_content_inspection_from_config_installs_tool_hook(
+        self, monkeypatch
+    ):
+        from src.main import configure_content_inspection_from_config
+        from src.tooling.runtime import TOOL_SERVICE
+
+        monkeypatch.setattr(
+            "src.main.config.untrusted_content_inspection_enabled", True
+        )
+        monkeypatch.setattr("src.main.config.untrusted_content_backend", "null")
+        monkeypatch.setattr("src.main.config.untrusted_content_inspection_mode", "warn")
+        monkeypatch.setattr(
+            "src.main.config.untrusted_content_fail_policy", "fail_open"
+        )
+
+        TOOL_SERVICE.clear_hooks()
+        try:
+            configure_content_inspection_from_config()
+            hook_types = [type(h).__name__ for h in TOOL_SERVICE.hooks]
+            assert "ContentInspectionHook" in hook_types
+        finally:
+            TOOL_SERVICE.clear_hooks()
+
+    def test_configure_content_inspection_from_config_removes_tool_hook_when_disabled(
+        self, monkeypatch
+    ):
+        from src.main import configure_content_inspection_from_config
+        from src.tooling.inspection_hook import ContentInspectionHook
+        from src.tooling.runtime import TOOL_SERVICE
+
+        monkeypatch.setattr(
+            "src.main.config.untrusted_content_inspection_enabled", False
+        )
+
+        TOOL_SERVICE.set_hooks([ContentInspectionHook()])
+        try:
+            configure_content_inspection_from_config()
+            hook_types = [type(h).__name__ for h in TOOL_SERVICE.hooks]
+            assert "ContentInspectionHook" not in hook_types
+        finally:
+            TOOL_SERVICE.clear_hooks()
+
+    def test_configure_content_inspection_from_config_rejects_unimplemented_backend(
+        self, monkeypatch
+    ):
+        from src.main import configure_content_inspection_from_config
+        from src.tooling.runtime import TOOL_SERVICE
+
+        monkeypatch.setattr(
+            "src.main.config.untrusted_content_inspection_enabled", True
+        )
+        monkeypatch.setattr("src.main.config.untrusted_content_backend", "http")
+        monkeypatch.setattr("src.main.config.untrusted_content_inspection_mode", "warn")
+        monkeypatch.setattr(
+            "src.main.config.untrusted_content_fail_policy", "fail_open"
+        )
+
+        TOOL_SERVICE.clear_hooks()
+        try:
+            with pytest.raises(ValueError, match="only 'null' is implemented"):
+                configure_content_inspection_from_config()
+        finally:
+            TOOL_SERVICE.clear_hooks()
+
     @patch("src.main.socket.getaddrinfo", side_effect=OSError("dns down"))
     def test_provider_preflight_logs_failures(self, _mock_dns):
         from src.main import run_provider_preflight

--- a/tests/tooling/test_inspection_hook.py
+++ b/tests/tooling/test_inspection_hook.py
@@ -1,0 +1,208 @@
+"""Tests for ContentInspectionHook — the TOOL_SERVICE hook adapter."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tooling.inspection_hook import ContentInspectionHook
+from src.tooling.inspection_service import INSPECTION_SERVICE, InspectionService
+from src.tooling.inspector import (
+    InspectionDecision,
+    InspectionEnvelope,
+    NullInspector,
+    SourceKind,
+)
+from src.tooling.runtime import ToolInvocation, ToolResult
+
+
+def _invocation(name: str = "test_tool", source: str = "toolnode") -> ToolInvocation:
+    return ToolInvocation(name=name, args={}, source=source, agent_key="test_agent")
+
+
+def _result(value: str = "output") -> ToolResult:
+    return ToolResult(value=value)
+
+
+# ---------------------------------------------------------------------------
+# before() is always a pass-through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_before_passthrough():
+    hook = ContentInspectionHook()
+    call = _invocation()
+    returned = await hook.before(call)
+    assert returned is call
+
+
+# ---------------------------------------------------------------------------
+# after() with NullInspector — no mutation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_after_null_inspector_passthrough():
+    """NullInspector → result unchanged."""
+    original_inspector = INSPECTION_SERVICE._inspector
+    original_mode = INSPECTION_SERVICE._mode
+    try:
+        INSPECTION_SERVICE.configure(NullInspector(), mode="warn")
+        hook = ContentInspectionHook()
+        result = await hook.after(_invocation(), _result("original"))
+        assert result.value == "original"
+        assert not result.blocked
+    finally:
+        INSPECTION_SERVICE.configure(original_inspector, mode=original_mode)
+
+
+# ---------------------------------------------------------------------------
+# after() in warn mode — content passes through even if flagged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_after_warn_mode_content_passes_through():
+    class FlagInspector:
+        async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+            return InspectionDecision(
+                action="block",
+                threat_level="high",
+                findings=["injection"],
+                reason="test",
+            )
+
+    original_inspector = INSPECTION_SERVICE._inspector
+    original_mode = INSPECTION_SERVICE._mode
+    try:
+        INSPECTION_SERVICE.configure(FlagInspector(), mode="warn")
+        hook = ContentInspectionHook()
+        result = await hook.after(_invocation(), _result("dangerous"))
+        # warn mode → original content returned
+        assert result.value == "dangerous"
+        assert not result.blocked
+    finally:
+        INSPECTION_SERVICE.configure(original_inspector, mode=original_mode)
+
+
+# ---------------------------------------------------------------------------
+# after() in block mode — TOOL_BLOCKED returned
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_after_block_mode_returns_blocked_result():
+    class BlockInspector:
+        async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+            return InspectionDecision(
+                action="block",
+                threat_level="critical",
+                findings=["injection"],
+                reason="blocked for test",
+            )
+
+    original_inspector = INSPECTION_SERVICE._inspector
+    original_mode = INSPECTION_SERVICE._mode
+    try:
+        INSPECTION_SERVICE.configure(BlockInspector(), mode="block")
+        hook = ContentInspectionHook()
+        result = await hook.after(_invocation(), _result("evil content"))
+        assert result.blocked is True
+        assert isinstance(result.value, str)
+        assert "TOOL_BLOCKED" in result.value
+    finally:
+        INSPECTION_SERVICE.configure(original_inspector, mode=original_mode)
+
+
+# ---------------------------------------------------------------------------
+# after() skips already-blocked results
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_after_skips_already_blocked():
+    class AlwaysBlockInspector:
+        call_count = 0
+
+        async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+            AlwaysBlockInspector.call_count += 1
+            return InspectionDecision(action="block", threat_level="high")
+
+    original_inspector = INSPECTION_SERVICE._inspector
+    original_mode = INSPECTION_SERVICE._mode
+    try:
+        inspector = AlwaysBlockInspector()
+        INSPECTION_SERVICE.configure(inspector, mode="block")
+        hook = ContentInspectionHook()
+        # Pre-blocked result
+        pre_blocked = ToolResult(value="TOOL_BLOCKED: earlier hook", blocked=True)
+        result = await hook.after(_invocation(), pre_blocked)
+        # Should return same blocked result without calling inspector
+        assert result.blocked is True
+        assert AlwaysBlockInspector.call_count == 0
+    finally:
+        INSPECTION_SERVICE.configure(original_inspector, mode=original_mode)
+
+
+# ---------------------------------------------------------------------------
+# after() in sanitize mode — content replaced
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_after_sanitize_mode_replaces_content():
+    class SanitizeInspector:
+        async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+            return InspectionDecision(
+                action="sanitize",
+                threat_level="medium",
+                sanitized_content="[safe]",
+            )
+
+    original_inspector = INSPECTION_SERVICE._inspector
+    original_mode = INSPECTION_SERVICE._mode
+    try:
+        INSPECTION_SERVICE.configure(SanitizeInspector(), mode="sanitize")
+        hook = ContentInspectionHook()
+        result = await hook.after(_invocation(), _result("dirty content"))
+        assert result.value == "[safe]"
+        assert not result.blocked
+    finally:
+        INSPECTION_SERVICE.configure(original_inspector, mode=original_mode)
+
+
+# ---------------------------------------------------------------------------
+# InspectionEnvelope is populated correctly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_envelope_populated_from_invocation():
+    captured: list[InspectionEnvelope] = []
+
+    class CapturingInspector:
+        async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+            captured.append(envelope)
+            return InspectionDecision(action="allow", threat_level="safe")
+
+    original_inspector = INSPECTION_SERVICE._inspector
+    original_mode = INSPECTION_SERVICE._mode
+    try:
+        INSPECTION_SERVICE.configure(CapturingInspector(), mode="warn")
+        hook = ContentInspectionHook()
+        call = ToolInvocation(
+            name="my_tool",
+            args={"q": "search"},
+            source="consultant",
+            agent_key="my_agent",
+        )
+        await hook.after(call, _result("content"))
+        assert len(captured) == 1
+        env = captured[0]
+        assert env.source_name == "my_tool"
+        assert env.tool_name == "my_tool"
+        assert env.agent_key == "my_agent"
+        assert env.source_kind == SourceKind.tool_output
+        assert env.content_text == "content"
+    finally:
+        INSPECTION_SERVICE.configure(original_inspector, mode=original_mode)

--- a/tests/tooling/test_inspection_service.py
+++ b/tests/tooling/test_inspection_service.py
@@ -1,0 +1,296 @@
+"""Tests for InspectionService and inspection primitives."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.tooling.inspection_service import (
+    InspectionService,
+    configure_content_inspection,
+)
+from src.tooling.inspector import (
+    CompositeInspector,
+    InspectionDecision,
+    InspectionEnvelope,
+    NullInspector,
+    SourceKind,
+)
+
+
+def _envelope(text: str = "hello") -> InspectionEnvelope:
+    return InspectionEnvelope(
+        content_text=text,
+        source_kind=SourceKind.web_search,
+        source_name="test",
+    )
+
+
+class _BlockingInspector:
+    async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+        return InspectionDecision(
+            action="block",
+            threat_level="high",
+            threat_types=["prompt_injection"],
+            findings=["injection detected"],
+            reason="test block",
+        )
+
+
+class _SanitizingInspector:
+    async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+        return InspectionDecision(
+            action="sanitize",
+            threat_level="medium",
+            sanitized_content="[sanitized]",
+            findings=["pii found"],
+        )
+
+
+class _FlaggingInspector:
+    """Returns allow with findings (non-trivial threat level)."""
+
+    async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+        return InspectionDecision(
+            action="allow",
+            threat_level="low",
+            findings=["suspicious pattern"],
+        )
+
+
+class _ErrorInspector:
+    async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+        raise RuntimeError("backend down")
+
+
+# ---------------------------------------------------------------------------
+# NullInspector
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_null_inspector_always_allows():
+    inspector = NullInspector()
+    decision = await inspector.inspect(_envelope("anything"))
+    assert decision.action == "allow"
+    assert decision.threat_level == "safe"
+
+
+# ---------------------------------------------------------------------------
+# InspectionService — warn mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_warn_mode_passes_content_through():
+    svc = InspectionService(_BlockingInspector(), mode="warn")
+    result = await svc.check(_envelope("dangerous content"))
+    assert result == "dangerous content"
+
+
+@pytest.mark.asyncio
+async def test_warn_mode_preserves_raw_content_shape_when_allowed():
+    raw_payload = {"results": [{"title": "hello"}]}
+    svc = InspectionService(NullInspector(), mode="warn")
+    result = await svc.check(
+        InspectionEnvelope(
+            content_text=str(raw_payload),
+            raw_content=raw_payload,
+            source_kind=SourceKind.web_search,
+            source_name="tavily",
+        )
+    )
+    assert result is raw_payload
+
+
+@pytest.mark.asyncio
+async def test_warn_mode_null_inspector_passthrough():
+    svc = InspectionService(NullInspector(), mode="warn")
+    result = await svc.check(_envelope("safe content"))
+    assert result == "safe content"
+
+
+# ---------------------------------------------------------------------------
+# InspectionService — sanitize mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sanitize_mode_replaces_content():
+    svc = InspectionService(_SanitizingInspector(), mode="sanitize")
+    result = await svc.check(_envelope("original"))
+    assert result == "[sanitized]"
+
+
+@pytest.mark.asyncio
+async def test_sanitize_mode_block_action_without_sanitized_content():
+    """block action with no sanitized_content → pass through in sanitize mode."""
+
+    class BlockNoSanitize:
+        async def inspect(self, envelope):
+            return InspectionDecision(action="block", threat_level="high")
+
+    svc = InspectionService(BlockNoSanitize(), mode="sanitize")
+    result = await svc.check(_envelope("content"))
+    assert result == "content"
+
+
+# ---------------------------------------------------------------------------
+# InspectionService — block mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_block_mode_returns_blocked_placeholder():
+    svc = InspectionService(_BlockingInspector(), mode="block")
+    result = await svc.check(_envelope("dangerous"))
+    assert result.startswith("TOOL_BLOCKED:")
+
+
+@pytest.mark.asyncio
+async def test_block_mode_null_inspector_passthrough():
+    svc = InspectionService(NullInspector(), mode="block")
+    result = await svc.check(_envelope("safe"))
+    assert result == "safe"
+
+
+# ---------------------------------------------------------------------------
+# Fail policies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fail_open_allows_on_backend_error():
+    svc = InspectionService(_ErrorInspector(), mode="block", fail_policy="fail_open")
+    result = await svc.check(_envelope("content"))
+    assert result == "content"
+
+
+@pytest.mark.asyncio
+async def test_fail_open_preserves_raw_content_shape_on_backend_error():
+    raw_payload = {"results": [{"title": "hello"}]}
+    svc = InspectionService(_ErrorInspector(), mode="block", fail_policy="fail_open")
+    result = await svc.check(
+        InspectionEnvelope(
+            content_text=str(raw_payload),
+            raw_content=raw_payload,
+            source_kind=SourceKind.web_search,
+            source_name="tavily",
+        )
+    )
+    assert result is raw_payload
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_blocks_on_backend_error():
+    svc = InspectionService(_ErrorInspector(), mode="block", fail_policy="fail_closed")
+    result = await svc.check(_envelope("content"))
+    assert result.startswith("TOOL_BLOCKED:")
+
+
+# ---------------------------------------------------------------------------
+# CompositeInspector strategies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_composite_any_block_blocks_when_any_blocks():
+    composite = CompositeInspector(
+        [NullInspector(), _BlockingInspector()], strategy="any_block"
+    )
+    decision = await composite.inspect(_envelope())
+    assert decision.action == "block"
+
+
+@pytest.mark.asyncio
+async def test_composite_any_block_allows_when_none_block():
+    composite = CompositeInspector(
+        [NullInspector(), NullInspector()], strategy="any_block"
+    )
+    decision = await composite.inspect(_envelope())
+    assert decision.action == "allow"
+
+
+@pytest.mark.asyncio
+async def test_composite_any_block_preserves_sanitize_when_no_blockers():
+    composite = CompositeInspector(
+        [NullInspector(), _SanitizingInspector()], strategy="any_block"
+    )
+    decision = await composite.inspect(_envelope())
+    assert decision.action == "sanitize"
+
+
+@pytest.mark.asyncio
+async def test_composite_majority_requires_more_than_half():
+    # 1 blocker out of 3 → not majority → allow
+    composite = CompositeInspector(
+        [NullInspector(), NullInspector(), _BlockingInspector()], strategy="majority"
+    )
+    decision = await composite.inspect(_envelope())
+    assert decision.action == "allow"
+
+
+@pytest.mark.asyncio
+async def test_composite_majority_blocks_when_majority():
+    # 2 blockers out of 3 → majority → block
+    composite = CompositeInspector(
+        [NullInspector(), _BlockingInspector(), _BlockingInspector()],
+        strategy="majority",
+    )
+    decision = await composite.inspect(_envelope())
+    assert decision.action == "block"
+
+
+@pytest.mark.asyncio
+async def test_composite_first_flag_returns_first_non_allow():
+    composite = CompositeInspector(
+        [_SanitizingInspector(), _BlockingInspector()], strategy="first_flag"
+    )
+    decision = await composite.inspect(_envelope())
+    assert decision.action == "sanitize"
+
+
+@pytest.mark.asyncio
+async def test_composite_ignores_single_backend_failure_when_others_succeed():
+    composite = CompositeInspector(
+        [_ErrorInspector(), _SanitizingInspector()], strategy="any_block"
+    )
+    decision = await composite.inspect(_envelope())
+    assert decision.action == "sanitize"
+
+
+@pytest.mark.asyncio
+async def test_composite_raises_when_all_backends_fail():
+    composite = CompositeInspector(
+        [_ErrorInspector(), _ErrorInspector()], strategy="any_block"
+    )
+    with pytest.raises(RuntimeError, match="backend down|content inspectors failed"):
+        await composite.inspect(_envelope())
+
+
+@pytest.mark.asyncio
+async def test_composite_empty_returns_allow():
+    composite = CompositeInspector([], strategy="any_block")
+    decision = await composite.inspect(_envelope())
+    assert decision.action == "allow"
+
+
+# ---------------------------------------------------------------------------
+# configure_content_inspection
+# ---------------------------------------------------------------------------
+
+
+def test_configure_content_inspection_replaces_backend():
+    from src.tooling.inspection_service import INSPECTION_SERVICE
+
+    original_inspector = INSPECTION_SERVICE._inspector
+    try:
+        configure_content_inspection(
+            NullInspector(), mode="block", fail_policy="fail_closed"
+        )
+        assert INSPECTION_SERVICE.mode == "block"
+        assert isinstance(INSPECTION_SERVICE._inspector, NullInspector)
+    finally:
+        # Restore
+        INSPECTION_SERVICE.configure(
+            original_inspector, mode="warn", fail_policy="fail_open"
+        )


### PR DESCRIPTION
## Summary                                                                                                                                       
                                                                                                                                                   
  Content-inspection hook for tool outputs + per-agent token budgets + container hardening + pipeline/ticker bug fixes + Trivy CI unblock.         
   
  ## Changes                                                                                                                                       
                                                                                                                                                 
  - `src/tooling/inspector.py` / `inspection_service.py` / `inspection_hook.py` — hook that sanitises every tool output before it reaches LLM      
  context; `NullInspector` default (zero overhead, opt-in)
  - `src/llm_budgets.py` — per-agent `max_tokens` fractions enforced at node construction                                                          
  - `src/agents/output_validation.py` — DATA_BLOCK numeric field coercion/validation                                                               
  - `src/ticker_policy.py` — exchange-suffix rules centralised; fixes cross-exchange base-symbol clashes                                           
  - `scripts/run_pipeline.sh` — fix: `DO NOT INITIATE` verdicts not parsed on restart                                                              
  - `Dockerfile`, `docker-compose.yml`, `scripts/check-environment.sh` — Podman-first hardening                                                    
  - `.github/workflows/security.yml` — `trivy-action` `0.28.0` → `0.35.0` (non-existent tag was silently blocking all Trivy jobs)                  
  - `CLAUDE.md` — note to audit pinned action versions on every workflow touch                                                                     
                                                                                                                                                   
  ## Type of Change                                                                                                                                
                                                                                                                                                 
  - [x] Bug fix                                                                                                                                    
  - [x] New feature
  - [x] Performance improvement                                                                                                                    
  - [x] Test additions/improvements                                                                                                              
  - [x] Documentation update

  ## Testing

  ```bash
  poetry run pytest tests/tooling/ tests/agents/test_output_validation.py tests/test_content_ingress_coverage.py tests/scripts/test_run_pipeline.py
   -v                                                                                                                                              
  poetry run ruff check src/
                                                                                                                                                   
  Additional Notes                                                                                                                                 
   
  ContentInspectionHook is opt-in — existing runs unaffected. Enable via configure_content_inspection(backend, mode) at startup.                   
  ```                                                                                                                                            
