### PR TITLE
Feat add consultant mcp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,14 @@ CONSULTANT_MODEL=gpt-4o
 # When disabled, the graph skips the consultant and routes directly from Research Manager to Trader
 ENABLE_CONSULTANT=true
 
+# Optional MCP support for narrow consultant cross-checks.
+# Copy config/mcp_servers.example.json to config/mcp_servers.json and then
+# point MCP_SERVERS_PATH at that local file.
+MCP_ENABLED=false
+CONSULTANT_MCP_ENABLED=false
+MCP_SERVERS_PATH=./config/mcp_servers.json
+MCP_USAGE_DB_PATH=./runtime/mcp_usage.db
+
 # Analogous to QUICK_MODEL below (used for Gemini)
 CONSULTANT_QUICK_MODEL=gpt-4o-mini
 

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ runtime/ibkr_dashboard/
 # Local configuration overrides
 local_config.py
 config.local.py
+.aider*

--- a/.gitignore
+++ b/.gitignore
@@ -180,4 +180,7 @@ runtime/ibkr_dashboard/
 # Local configuration overrides
 local_config.py
 config.local.py
+config/mcp_servers.json
+runtime/mcp_usage.db
+runtime/mcp_usage.db-*
 .aider*

--- a/README.md
+++ b/README.md
@@ -148,6 +148,49 @@ Practical notes:
 - Start with `warn` to inspect logs and false positives before moving to `sanitize` or `block`.
 - `fail_open` is the safer rollout default for a local operator workflow; `fail_closed` is stricter but can suppress content when the inspector itself errors.
 
+### Optional MCP Cross-Checks for the Consultant
+
+The Consultant can optionally use narrow MCP-backed spot checks to verify a small number of material claims without turning the whole graph into a free-form MCP client.
+
+Current v1 posture:
+
+- MCP is disabled by default.
+- Consultant access is intentionally narrow and curated.
+- FMP MCP is used for fundamentals/quote spot checks via FMP's dispatcher tools (`statements`, `quote`).
+- Twelve Data MCP is **disabled** in the shipped registry — their public surface only exposes a free-form AI router (`u-tool`) that does not fit the narrow-allowlist contract. Re-enable only if a structured per-metric surface ships.
+- Consultant MCP calls flow through the normal tool hook plane, and when
+  untrusted-content inspection is enabled their output is inspected with
+  `SourceKind.mcp_tool_output` before it becomes prompt-visible.
+- `scripts/mcp_smoke.py` is a permanent diagnostic that exercises the MCP path end-to-end without an LLM in the loop — useful for "is MCP actually moving bytes?" checks. See [docs/MCP.md](docs/MCP.md#smoke-testing-the-integration).
+
+Setup:
+
+```bash
+cp config/mcp_servers.example.json config/mcp_servers.json
+```
+
+Then set in `.env`:
+
+```bash
+MCP_ENABLED=true
+CONSULTANT_MCP_ENABLED=true
+MCP_SERVERS_PATH=./config/mcp_servers.json
+MCP_USAGE_DB_PATH=./runtime/mcp_usage.db
+FMP_API_KEY=...
+TWELVE_DATA_API_KEY=...
+```
+
+Operational notes:
+
+- Keep secrets in `.env`, not in the JSON registry.
+- `config/mcp_servers.json` is intentionally ignored so local server selections and limits do not dirty the repo.
+- If `MCP_ENABLED=true` but the registry file is missing, empty, or has no enabled
+  servers, runtime startup logs a warning and the consultant MCP wrappers stay hidden.
+- `trust_tier` must be one of `official_vendor`, `community`, or `unknown`.
+- Supported transports in v1 are `streamable_http` and `stdio`.
+- Supported auth modes in v1 are `none`, `query_api_key`, `header_bearer`, and `header_static`.
+- The usage database tracks local MCP budgets only; it does not replace vendor-side rate limits.
+
 ### Confirm the Core Path Works
 
 ```bash

--- a/config/mcp_servers.example.json
+++ b/config/mcp_servers.example.json
@@ -1,0 +1,41 @@
+{
+  "servers": [
+    {
+      "id": "fmp_remote",
+      "description": "Official FMP MCP endpoint. Uses dispatcher tools (statements/quote take an 'endpoint' arg).",
+      "transport": "streamable_http",
+      "base_url": "https://financialmodelingprep.com/mcp",
+      "auth": {
+        "type": "query_api_key",
+        "param": "apikey",
+        "env_var": "FMP_API_KEY"
+      },
+      "enabled": false,
+      "scopes": ["consultant"],
+      "tool_allowlist": [
+        "statements",
+        "quote"
+      ],
+      "daily_call_limit": 250,
+      "per_run_limit": 3,
+      "trust_tier": "official_vendor"
+    },
+    {
+      "id": "twelvedata_remote",
+      "description": "Twelve Data public MCP only exposes 'u-tool' (free-form AI router) and 'doc-tool'. Neither fits the consultant's narrow-allowlist contract; leave disabled.",
+      "transport": "streamable_http",
+      "base_url": "https://mcp.twelvedata.com/mcp",
+      "auth": {
+        "type": "query_api_key",
+        "param": "apikey",
+        "env_var": "TWELVE_DATA_API_KEY"
+      },
+      "enabled": false,
+      "scopes": ["consultant"],
+      "tool_allowlist": [],
+      "daily_call_limit": 250,
+      "per_run_limit": 2,
+      "trust_tier": "official_vendor"
+    }
+  ]
+}

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,174 @@
+# Model Context Protocol (MCP) integration
+
+The consultant agent can cross-validate analyst claims against vendor MCP
+servers (currently the FMP MCP server). The consultant-facing MCP wrappers
+route calls through the normal `ToolExecutionService` hook chain, so audit
+logging, argument policy, content inspection, and per-server budget can all
+observe those calls under the canonical name `mcp__<server>__<tool>`.
+
+`MCPRuntime.call_tool()` still exists as a convenience/testing path, but it is
+not the recommended agent-facing integration surface for this repo.
+
+## Vendor surface notes (verified May 2026)
+
+Run `python /tmp/mcp_list_tools.py` (or the equivalent of `session.list_tools()`)
+against any new vendor before adding it to the registry — assumed tool names
+are unreliable.
+
+- **FMP** uses a *dispatcher* pattern. Top-level tools (`statements`, `quote`,
+  `analyst`, `chart`, etc.) take an `endpoint` enum argument that selects the
+  actual operation. So fetching financial ratios looks like
+  `tool="statements", arguments={"symbol": ..., "endpoint": "metrics-ratios-ttm"}`.
+  The consultant wrapper's `_FMP_METRIC_DISPATCH` table in
+  `src/consultant_tools.py` encodes the metric → (tool, endpoint) mapping.
+  When adding a new metric, run `mcp_list_tools.py` and pick from the printed
+  `endpoint_enum` for the relevant tool.
+- **Twelve Data** is intentionally **not exposed** in this repo. Their public
+  MCP only publishes `u-tool` (a free-form AI router) and `doc-tool`. Neither
+  fits the consultant's narrow-allowlist + structured-payload contract; the
+  registry entry is left with `enabled: false` until they ship structured
+  per-metric tools.
+
+## Configuration
+
+1. Set environment variables in `.env`:
+
+   ```ini
+   MCP_ENABLED=true
+   MCP_SERVERS_PATH=config/mcp_servers.json
+   MCP_USAGE_DB_PATH=runtime/mcp_usage.db
+   CONSULTANT_MCP_ENABLED=true
+   ```
+
+2. Copy `config/mcp_servers.example.json` to `config/mcp_servers.json` and set
+   `enabled: true` on the entries you want to use. Provide the API key envs
+   referenced by `auth.env_var` (e.g. `FMP_API_KEY`, `TWELVE_DATA_API_KEY`).
+
+If `MCP_ENABLED=true` and the registry file is missing, empty, or contains no
+enabled servers, runtime startup logs a warning and consultant MCP wrappers stay
+hidden.
+
+## Server registry schema
+
+Each entry in `config/mcp_servers.json` declares one MCP server:
+
+| Field              | Required | Notes                                                       |
+| ------------------ | -------- | ----------------------------------------------------------- |
+| `id`               | yes      | Stable identifier; used as the `mcp__<id>__*` name prefix.  |
+| `transport`        | yes      | `"streamable_http"` or `"stdio"`.                           |
+| `base_url`         | http     | HTTPS URL for `streamable_http` servers.                    |
+| `command`/`args`   | stdio    | Process spec for `stdio` servers.                           |
+| `auth`             | no       | `none` / `query_api_key` / `header_bearer` / `header_static`. Non-`none` types must set `env_var`. |
+| `enabled`          | no       | `false` keeps the entry in the registry but hides it.        |
+| `scopes`           | yes      | Which agent scopes may use this server (e.g. `"consultant"`). |
+| `tool_allowlist`   | yes      | Tools the consultant may invoke; everything else is rejected. |
+| `daily_call_limit` | no       | 0 disables; otherwise upper bound per UTC day per server.    |
+| `per_run_limit`    | no       | 0 disables; otherwise upper bound per analysis run.          |
+| `trust_tier`       | yes      | `official_vendor` / `community` / `unknown`. The content inspector applies a lower threshold for `official_vendor` structured payloads. |
+
+## Trust tier vocabulary
+
+- `official_vendor` — first-party endpoint maintained by the data provider
+  (e.g. Twelve Data's own MCP server). Structured-financial payloads from
+  `official_vendor` sources receive a halved heuristic weight.
+- `community` — third-party endpoint with a public maintainer.
+- `unknown` — anything else; the inspector applies its default weights.
+
+## Scope semantics
+
+`scopes` is an allowlist. The consultant wrappers call
+`MCPRuntime.execute_raw(..., scope="consultant")` through the shared tool hook
+chain; servers without `"consultant"` in `scopes` raise
+`MCPCallError(category=CONFIG)` before any network call.
+
+## Budget interaction
+
+`MCPBudgetHook` runs as part of the shared hook chain and gates each call:
+
+- `before()` blocks the call when `daily_call_limit` or `per_run_limit` is
+  exhausted (raises `ToolCallBlocked`, surfaced as a `TOOL_BLOCKED:` sentinel
+  in the consultant tool's structured failure JSON).
+- `after()` records one upstream consumption for any non-blocked result —
+  including upstream `isError=true` payloads, which still consume vendor
+  quota.
+
+Counts persist in the SQLite database at `MCP_USAGE_DB_PATH`. Rows older than
+the retention window are swept on startup.
+
+## Diagnosing a blocked call
+
+The consultant tool `spot_check_metric_mcp_fmp` always returns JSON. On block
+or failure it emits:
+
+```json
+{
+  "error": "...",
+  "ticker": "...",
+  "metric": "...",
+  "provider": "fmp",
+  "failure_kind": "config|auth|transport|protocol|tool_error|inspection|budget|inspection_blocked",
+  "retryable": true,
+  "source": "fmp_mcp"
+}
+```
+
+`failure_kind` mirrors `MCPErrorCategory` plus `inspection_blocked` for hook-
+level blocks. Use the value to disambiguate: `config` (allowlist/scope/spec),
+`auth` (401/403, vendor cooldown), `transport` (5xx/429/network),
+`tool_error` (vendor returned `isError=true`), `inspection` /
+`inspection_blocked` (content inspector rejected the payload).
+
+If the inspector sanitizes a payload into plain text instead of blocking it, the
+consultant wrappers return a JSON object with `text_payload` and
+`note="mcp_payload_sanitized_or_textual"` rather than mislabeling the result as
+a protocol failure.
+
+## Smoke testing the integration
+
+`scripts/mcp_smoke.py` is the canonical way to answer "is MCP actually moving
+bytes right now?" without burning tokens or waiting for a full analysis. It
+bypasses the consultant LLM and calls `spot_check_metric_mcp_fmp` directly
+through the full hook chain — same canonical `mcp__<server>__<tool>` name,
+same audit/policy/inspection/budget hooks, real vendor traffic.
+
+```bash
+# Default: 6914.T currentPrice
+poetry run python scripts/mcp_smoke.py
+
+# Pick any (ticker, metric) covered by _FMP_METRIC_DISPATCH
+poetry run python scripts/mcp_smoke.py --ticker AAPL --metric trailingPE
+
+# Quieter — suppresses SDK/hook INFO chatter on stderr
+poetry run python scripts/mcp_smoke.py --quiet
+```
+
+Exit codes are CI-friendly:
+
+| code | meaning                                                          |
+| ---- | ---------------------------------------------------------------- |
+| `0`  | success — vendor returned a numeric `value`                      |
+| `1`  | vendor- or hook-level failure — see `failure_kind` in the JSON   |
+| `2`  | config / runtime not available (MCP disabled or registry unread) |
+| `3`  | unexpected internal error (architectural failure, not vendor)    |
+
+Structured JSON is always printed to stdout — pipe through `jq` for further
+inspection. A typical free-tier FMP run produces `failure_kind="tool_error"`
+with a 402 message — that means the integration is healthy and the limitation
+is purely the FMP plan tier.
+
+## Adding a new server
+
+1. Add an entry to `config/mcp_servers.json` matching the schema above.
+2. Restrict `tool_allowlist` to the smallest useful surface — the consultant
+   should not see vendor admin or write tools.
+3. Choose a `trust_tier` honestly; default to `unknown` for new entries.
+4. Pick conservative `per_run_limit` / `daily_call_limit` so the consultant
+   cannot exhaust vendor quota during a single analysis.
+5. Set `enabled: true` once the API key envs are populated.
+
+For `stdio` servers, auth-backed environment variables are injected into the
+subprocess environment automatically. Extra non-secret environment variable names
+can still be listed under `env_vars`.
+
+The runtime validates all of the above eagerly; a bad entry raises
+`ValueError` at startup rather than at first call.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3578,6 +3578,39 @@ traitlets = "*"
 test = ["flake8", "nbdime", "nbval", "notebook", "pytest"]
 
 [[package]]
+name = "mcp"
+version = "1.27.0"
+description = "Model Context Protocol SDK"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741"},
+    {file = "mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83"},
+]
+
+[package.dependencies]
+anyio = ">=4.5"
+httpx = ">=0.27.1"
+httpx-sse = ">=0.4"
+jsonschema = ">=4.20.0"
+pydantic = ">=2.11.0,<3.0.0"
+pydantic-settings = ">=2.5.2"
+pyjwt = {version = ">=2.10.1", extras = ["crypto"]}
+python-multipart = ">=0.0.9"
+pywin32 = {version = ">=310", markers = "sys_platform == \"win32\""}
+sse-starlette = ">=1.6.1"
+starlette = ">=0.27"
+typing-extensions = ">=4.9.0"
+typing-inspection = ">=0.4.1"
+uvicorn = {version = ">=0.31.1", markers = "sys_platform != \"emscripten\""}
+
+[package.extras]
+cli = ["python-dotenv (>=1.0.0)", "typer (>=0.16.0)"]
+rich = ["rich (>=13.9.4)"]
+ws = ["websockets (>=15.0.1)"]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 description = "Markdown URL utilities"
@@ -5575,6 +5608,27 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+description = "JSON Web Token implementation in Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
+    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
+]
+
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 description = "pyparsing - Classes and methods to define and execute parsing grammars"
@@ -5763,6 +5817,18 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.27"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645"},
+    {file = "python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602"},
+]
+
+[[package]]
 name = "pytokens"
 version = "0.4.1"
 description = "A Fast, spec compliant Python 3.14+ tokenizer that runs on older Pythons."
@@ -5827,6 +5893,37 @@ groups = ["main"]
 files = [
     {file = "pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a"},
     {file = "pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1"},
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+description = "Python for Window Extensions"
+optional = false
+python-versions = "*"
+groups = ["main"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3"},
+    {file = "pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b"},
+    {file = "pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b"},
+    {file = "pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151"},
+    {file = "pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503"},
+    {file = "pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2"},
+    {file = "pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31"},
+    {file = "pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067"},
+    {file = "pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852"},
+    {file = "pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d"},
+    {file = "pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d"},
+    {file = "pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a"},
+    {file = "pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee"},
+    {file = "pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87"},
+    {file = "pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42"},
+    {file = "pywin32-311-cp38-cp38-win32.whl", hash = "sha256:6c6f2969607b5023b0d9ce2541f8d2cbb01c4f46bc87456017cf63b73f1e2d8c"},
+    {file = "pywin32-311-cp38-cp38-win_amd64.whl", hash = "sha256:c8015b09fb9a5e188f83b7b04de91ddca4658cee2ae6f3bc483f0b21a77ef6cd"},
+    {file = "pywin32-311-cp39-cp39-win32.whl", hash = "sha256:aba8f82d551a942cb20d4a83413ccbac30790b50efb89a75e4f586ac0bb8056b"},
+    {file = "pywin32-311-cp39-cp39-win_amd64.whl", hash = "sha256:e0c4cfb0621281fe40387df582097fd796e80430597cb9944f0ae70447bacd91"},
+    {file = "pywin32-311-cp39-cp39-win_arm64.whl", hash = "sha256:62ea666235135fee79bb154e695f3ff67370afefd71bd7fea7512fc70ef31e3d"},
 ]
 
 [[package]]
@@ -6472,6 +6569,29 @@ pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.1"
+description = "SSE plugin for Starlette"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "sse_starlette-3.4.1-py3-none-any.whl", hash = "sha256:6b43cf21f1d574d582a6e1b0cfbde1c94dc86a32a701a7168c99c4475c6bd1d0"},
+    {file = "sse_starlette-3.4.1.tar.gz", hash = "sha256:f780bebcf6c8997fe514e3bd8e8c648d8284976b391c8bed0bcb1f611632b555"},
+]
+
+[package.dependencies]
+anyio = ">=4.7.0"
+starlette = ">=0.49.1"
+
+[package.extras]
+daphne = ["daphne (>=4.2.0)"]
+examples = ["fastapi (>=0.115.12)", "pydantic (>=2)", "uvicorn (>=0.34.0)"]
+examples-db = ["aiosqlite (>=0.21.0)", "sqlalchemy[asyncio] (>=2.0.41)"]
+granian = ["granian (>=2.3.1)"]
+uvicorn = ["uvicorn (>=0.34.0)"]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -6490,6 +6610,25 @@ pure-eval = "*"
 
 [package.extras]
 tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+description = "The little ASGI library that shines."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b"},
+    {file = "starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""}
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "stockstats"
@@ -7793,4 +7932,4 @@ writer = ["langchain-anthropic"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "4cf53b61ea2e1a26b04f643391863206e7f3b52b811a2830f6ea5149f3d1edd6"
+content-hash = "05a96f91de96f4be3d1bb5760187ab7acbbc4db0ae7198de8f1dc590e61e1cf8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ flask = "^3.1.3"
 markdown = "^3.10.2"
 nh3 = "^0.3.1"
 langchain-text-splitters = ">=1.1.2"
+mcp = ">=1.26.0,<2.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.2"

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Permanent diagnostic for the MCP integration.
+
+Bypasses the consultant agent's discretion and calls
+``spot_check_metric_mcp_fmp`` directly through the full hook chain (audit,
+argument-policy, content-inspection, MCPBudgetHook) under the canonical
+``mcp__<server>__<tool>`` name. Use this any time the question is "is the
+MCP integration actually moving bytes?" — the answer arrives in ~5s and is
+deterministic (no LLM in the loop).
+
+Exit codes
+----------
+  0  success — vendor returned a numeric ``value``
+  1  vendor- or hook-level failure — see ``failure_kind`` in the JSON
+  2  config / runtime not available — MCP is disabled or registry unreadable
+  3  unexpected internal error (architectural failure, not a vendor failure)
+
+Structured JSON is always printed to stdout so it can be piped into ``jq``
+or grepped in CI. Diagnostic INFO lines from the SDK / hooks go to stderr
+unless the caller explicitly raises log levels.
+
+Examples
+--------
+    poetry run python scripts/mcp_smoke.py
+    poetry run python scripts/mcp_smoke.py --ticker AAPL --metric currentPrice
+    poetry run python scripts/mcp_smoke.py --ticker 6914.T --metric trailingPE --quiet
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import sys
+
+from src.consultant_tools import spot_check_metric_mcp_fmp
+from src.main import build_runtime_services_from_config
+from src.runtime_services import use_runtime_services
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Direct-call MCP smoke test bypassing the consultant LLM.",
+    )
+    parser.add_argument(
+        "--ticker",
+        default="6914.T",
+        help="Stock ticker to test (default: 6914.T)",
+    )
+    parser.add_argument(
+        "--metric",
+        default="currentPrice",
+        help=(
+            "Metric to fetch — see _FMP_METRIC_DISPATCH in "
+            "src/consultant_tools.py (default: currentPrice)"
+        ),
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Silence SDK/hook INFO chatter on stderr",
+    )
+    return parser.parse_args()
+
+
+async def _run(ticker: str, metric: str) -> tuple[int, dict]:
+    services = build_runtime_services_from_config(enable_tool_audit=True)
+    if services.mcp_runtime is None:
+        return 2, {
+            "smoke_status": "no_mcp_runtime",
+            "hint": "Set MCP_ENABLED=true and ensure config/mcp_servers.json has at least one enabled server.",
+        }
+
+    with use_runtime_services(services):
+        raw = await spot_check_metric_mcp_fmp.ainvoke(
+            {"ticker": ticker, "metric": metric}
+        )
+
+    payload = json.loads(raw)
+
+    # The wrapper returns either a success shape (with "value") or a failure
+    # shape (with "failure_kind"). Map either onto a meaningful exit code.
+    if "value" in payload:
+        return 0, payload
+    if payload.get("failure_kind") == "config_error":
+        return 2, payload
+    return 1, payload
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.quiet:
+        # Hush the SDK + hook chain INFO chatter; keep WARNING+ visible.
+        logging.getLogger().setLevel(logging.WARNING)
+        for name in ("mcp", "httpx", "src"):
+            logging.getLogger(name).setLevel(logging.WARNING)
+
+    try:
+        exit_code, payload = asyncio.run(_run(args.ticker, args.metric))
+    except Exception as exc:  # pragma: no cover - smoke harness, not library code
+        json.dump(
+            {
+                "smoke_status": "internal_error",
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+            sys.stdout,
+            indent=2,
+        )
+        print()
+        return 3
+
+    json.dump(payload, sys.stdout, indent=2)
+    print()
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/async_utils.py
+++ b/src/async_utils.py
@@ -1,0 +1,187 @@
+"""Concurrency utilities — hard timeouts, pending-task introspection.
+
+Why this exists
+---------------
+``asyncio.wait_for`` cancels the inner task on timeout, then awaits the
+cancelled task before raising ``TimeoutError``. When the inner task is
+``await asyncio.to_thread(blocking_call)`` and the blocking call is stuck in
+a socket read with no library-level timeout, the thread cannot be cancelled,
+so ``wait_for`` waits forever for the cancelled task to finish — effectively
+no timeout. Hangs in this codebase trace back to this pattern: yfinance,
+yahooquery, Tavily, and DDG all run sync HTTP under ``to_thread`` and may not
+honor cancellation promptly.
+
+``run_with_hard_timeout`` is a *deadline-only* alternative: when the timeout
+expires it raises ``TimeoutError`` immediately, leaving the inner task to
+finish (or never finish) in the background. The caller proceeds. The orphan
+is silenced so it doesn't trigger an "exception was never retrieved" warning.
+
+This is paired with ``install_pending_task_dump_handler``, which on SIGUSR1
+dumps every pending asyncio task and its current stack — invaluable for
+diagnosing future hangs (``kill -USR1 <pid>``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import signal
+import sys
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+T = TypeVar("T")
+
+
+def _silence_orphan(task: asyncio.Task[Any], *, label: str) -> None:
+    """Drain *task*'s exception when it eventually finishes, so no warning fires."""
+
+    def _drain(t: asyncio.Task[Any]) -> None:
+        if t.cancelled():
+            return
+        exc = t.exception()
+        if exc is not None:
+            logger.debug(
+                "hard_timeout_orphan_failed",
+                label=label,
+                error_type=type(exc).__name__,
+            )
+
+    task.add_done_callback(_drain)
+
+
+async def run_with_hard_timeout(
+    coro: Awaitable[T],
+    *,
+    timeout: float,
+    label: str,
+) -> T:
+    """Await *coro* up to *timeout* seconds; raise TimeoutError without waiting on cleanup.
+
+    Unlike ``asyncio.wait_for``, this does not block on the inner task after the
+    timeout fires. The inner task is cancelled best-effort and orphaned: if the
+    underlying code can honor cancellation it will, if not the thread/task
+    lives on but no longer blocks the caller. Any exception the orphan raises
+    later is silenced.
+
+    *label* is logged on timeout to make orphan tasks attributable.
+    """
+    if timeout <= 0:
+        raise ValueError(f"timeout must be positive, got {timeout!r}")
+
+    task: asyncio.Task[T] = asyncio.ensure_future(coro)
+    try:
+        done, _pending = await asyncio.wait({task}, timeout=timeout)
+    except BaseException:
+        # Outer cancellation, KeyboardInterrupt, etc. — propagate after asking
+        # the inner to stop. We do not wait on it.
+        if not task.done():
+            task.cancel()
+            _silence_orphan(task, label=label)
+        raise
+
+    if task in done:
+        return task.result()
+
+    # Timeout: orphan the task.
+    task.cancel()
+    _silence_orphan(task, label=label)
+    logger.warning(
+        "hard_timeout_exceeded",
+        label=label,
+        timeout_seconds=timeout,
+    )
+    raise asyncio.TimeoutError(f"{label!r} exceeded hard timeout of {timeout:.1f}s")
+
+
+def dump_pending_tasks(
+    *,
+    loop: asyncio.AbstractEventLoop | None = None,
+    frame_limit: int = 8,
+) -> list[dict[str, Any]]:
+    """Return one record per pending asyncio task with name, coro, and stack.
+
+    Safe to call from any context that has a running loop. Returns an empty
+    list if no loop is available.
+    """
+    try:
+        running_loop = loop or asyncio.get_running_loop()
+    except RuntimeError:
+        return []
+
+    records: list[dict[str, Any]] = []
+    for task in asyncio.all_tasks(running_loop):
+        if task.done():
+            continue
+        coro = task.get_coro()
+        stack_lines: list[str] = []
+        try:
+            for frame in task.get_stack(limit=frame_limit):
+                stack_lines.append(
+                    f"{frame.f_code.co_filename}:{frame.f_lineno} in {frame.f_code.co_name}"
+                )
+        except Exception:  # pragma: no cover - defensive
+            stack_lines = ["<stack unavailable>"]
+        records.append(
+            {
+                "name": task.get_name(),
+                "coro": getattr(coro, "__qualname__", repr(coro)),
+                "stack": stack_lines,
+            }
+        )
+    return records
+
+
+def install_pending_task_dump_handler(
+    *,
+    sig: int = signal.SIGUSR1,
+) -> Callable[[], None]:
+    """Install a signal handler that logs all pending asyncio tasks.
+
+    Trigger with ``kill -USR1 <pid>``. Returns a cleanup callable that removes
+    the handler. No-op (and returns a no-op cleanup) on platforms without
+    SIGUSR1, e.g. Windows.
+    """
+    if not hasattr(signal, "SIGUSR1") or sys.platform == "win32":
+        return lambda: None
+
+    previous = signal.getsignal(sig)
+
+    def _handler(_signum: int, _frame: Any) -> None:
+        records = dump_pending_tasks()
+        logger.warning(
+            "pending_tasks_dump",
+            count=len(records),
+            tasks=records,
+        )
+        # Also write a human-readable copy to stderr so it shows up in tee'd logs
+        # even if structlog rendering is configured for a non-stderr sink.
+        sys.stderr.write(f"[pending_tasks_dump] {len(records)} pending task(s)\n")
+        for rec in records:
+            sys.stderr.write(f"  - {rec['name']} ({rec['coro']})\n")
+            for line in rec["stack"]:
+                sys.stderr.write(f"      {line}\n")
+        sys.stderr.flush()
+
+    try:
+        signal.signal(sig, _handler)
+    except (ValueError, OSError):  # pragma: no cover - non-main-thread path
+        return lambda: None
+
+    def _uninstall() -> None:
+        try:
+            signal.signal(sig, previous if previous is not None else signal.SIG_DFL)
+        except (ValueError, OSError):  # pragma: no cover
+            pass
+
+    return _uninstall
+
+
+__all__ = [
+    "dump_pending_tasks",
+    "install_pending_task_dump_handler",
+    "run_with_hard_timeout",
+]

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,7 @@ Migration Notes (Dec 2025):
 - Config class alias maintained for backwards compatibility
 """
 
+import functools
 import logging
 import os
 import sys
@@ -130,6 +131,27 @@ def _parse_env_file() -> dict:
         logger.warning(f"Could not parse .env file: {e}")
 
     return env_values
+
+
+@functools.lru_cache(maxsize=1)
+def _cached_env_file_values() -> dict[str, str]:
+    """Memoized accessor for `.env` values; cleared by tests via cache_clear()."""
+    return _parse_env_file()
+
+
+def get_env_value(name: str) -> str | None:
+    """Resolve an environment variable by name with `.env` fallback.
+
+    The repo loads `.env` via pydantic-settings into the ``Settings`` model;
+    raw ``os.getenv`` does not see those values. Code paths that look up env
+    vars by *name* (e.g., MCP server auth, where the variable name is data-
+    driven from the registry) should use this helper so the `.env` file is
+    honored consistently with shell-exported values winning when both are set.
+    """
+    value = os.getenv(name)
+    if value:
+        return value
+    return _cached_env_file_values().get(name)
 
 
 def _check_env_overrides() -> None:
@@ -582,7 +604,7 @@ class Settings(BaseSettings):
         description="Path to the MCP server registry JSON file",
     )
     mcp_usage_db_path: Path = Field(
-        default=Path("./mcp_usage.db"),
+        default=Path("./runtime/mcp_usage.db"),
         validation_alias="MCP_USAGE_DB_PATH",
         description="Path to the SQLite database for MCP usage tracking",
     )
@@ -774,6 +796,7 @@ class Settings(BaseSettings):
             self.data_cache_dir,
             Path(self.chroma_persist_directory),
             self.images_dir,
+            self.mcp_usage_db_path.parent,
         ]:
             directory.mkdir(parents=True, exist_ok=True)
 

--- a/src/config.py
+++ b/src/config.py
@@ -565,6 +565,28 @@ class Settings(BaseSettings):
         ),
     )
 
+    # --- MCP Client Configuration ---
+    mcp_enabled: bool = Field(
+        default=False,
+        validation_alias="MCP_ENABLED",
+        description="Enable MCP client integration for cross-checks",
+    )
+    consultant_mcp_enabled: bool = Field(
+        default=False,
+        validation_alias="CONSULTANT_MCP_ENABLED",
+        description="Enable MCP tools for the Consultant agent (requires mcp_enabled)",
+    )
+    mcp_servers_path: Path = Field(
+        default=Path("./config/mcp_servers.json"),
+        validation_alias="MCP_SERVERS_PATH",
+        description="Path to the MCP server registry JSON file",
+    )
+    mcp_usage_db_path: Path = Field(
+        default=Path("./mcp_usage.db"),
+        validation_alias="MCP_USAGE_DB_PATH",
+        description="Path to the SQLite database for MCP usage tracking",
+    )
+
     # --- Telemetry & System Overrides ---
     # These settings are exported to os.environ for third-party libraries
     # that read directly from environment variables (ChromaDB, gRPC).
@@ -743,6 +765,8 @@ class Settings(BaseSettings):
         )
         self.images_dir = Path(os.path.expanduser(str(self.images_dir)))
         self.prompts_dir = Path(os.path.expanduser(str(self.prompts_dir)))
+        self.mcp_servers_path = Path(os.path.expanduser(str(self.mcp_servers_path)))
+        self.mcp_usage_db_path = Path(os.path.expanduser(str(self.mcp_usage_db_path)))
 
         # Create required directories
         for directory in [

--- a/src/consultant_tools.py
+++ b/src/consultant_tools.py
@@ -22,7 +22,9 @@ import yfinance as yf
 from langchain_core.tools import tool
 
 from src.error_safety import safe_error_payload, summarize_exception
+from src.config import config
 from src.runtime_diagnostics import classify_failure
+from src.runtime_services import get_current_runtime_services
 
 logger = structlog.get_logger(__name__)
 
@@ -316,15 +318,125 @@ async def spot_check_metric_alt(
         return json.dumps(safe_payload)
 
 
+@tool("spot_check_metric_mcp_fmp")
+async def spot_check_metric_mcp_fmp(
+    ticker: Annotated[str, "Stock ticker (e.g., 7203.T, 0005.HK)"],
+    metric: Annotated[str, "Metric name (e.g., trailingPE, debtToEquity)"],
+) -> str:
+    """Fetch a single financial metric from the **official FMP MCP** server.
+
+    This is an independent, MCP‑based cross‑check that does not rely on
+    the main pipeline's yfinance‑driven DATA_BLOCK.  Returns compact JSON.
+
+    Use when you suspect a specific number in the analyst reports is wrong
+    or when DATA_BLOCK and narrative claims diverge.
+    """
+    _METRIC_TO_MCP_TOOL = {
+        "trailingPE": "ratios",
+        "forwardPE": "ratios",
+        "priceToBook": "ratios",
+        "debtToEquity": "ratios",
+        "returnOnEquity": "ratios",
+        "returnOnAssets": "ratios",
+        "operatingMargins": "ratios",
+        "dividendYield": "ratios",
+        "payoutRatio": "ratios",
+        "currentRatio": "ratios",
+        "freeCashflow": "cash-flow-statement",
+        "operatingCashflow": "cash-flow-statement",
+        "totalRevenue": "income-statement",
+        "netIncomeToCommon": "income-statement",
+        "currentPrice": "quote",
+        "marketCap": "quote",
+    }
+
+    tool_name = _METRIC_TO_MCP_TOOL.get(metric, "ratios")
+    services = get_current_runtime_services()
+    if services is None or services.mcp_runtime is None:
+        return json.dumps({"error": "mcp_not_available", "ticker": ticker, "metric": metric})
+
+    try:
+        result_raw = await services.mcp_runtime.call_tool(
+            "fmp_remote", tool_name, {"symbol": ticker}, agent_key="consultant"
+        )
+    except Exception as exc:
+        return json.dumps({"error": str(exc), "ticker": ticker, "metric": metric, "source": "fmp_mcp"})
+
+    try:
+        data = json.loads(result_raw)
+        payload = data.get("result") if isinstance(data, dict) else data
+        if isinstance(payload, dict):
+            value = payload.get(metric)
+            return json.dumps(
+                {"ticker": ticker, "metric": metric, "value": value, "source": "fmp_mcp"}
+            )
+    except Exception:
+        pass
+    return result_raw
+
+
+@tool("spot_check_price_or_indicator_mcp_twelvedata")
+async def spot_check_price_or_indicator_mcp_twelvedata(
+    ticker: Annotated[str, "Stock ticker (e.g., 7203.T, 0005.HK)"],
+    query: Annotated[
+        str, "One of 'price', 'volume', 'rsi', 'macd', or 'quote'"
+    ],
+) -> str:
+    """Fetch price / volume / technical indicator from **Twelve Data MCP**.
+
+    Use only to verify a specific quote or indicator when the main pipeline
+    and FMP disagree.  Never enable the “u‑tool” for consultant checks.
+
+    Returns compact JSON.
+    """
+    services = get_current_runtime_services()
+    if services is None or services.mcp_runtime is None:
+        return json.dumps(
+            {"error": "mcp_not_available", "ticker": ticker, "query": query}
+        )
+
+    allowed_tools = {"price", "quote"}
+    tool_name = query if query in allowed_tools else "quote"
+    try:
+        result_raw = await services.mcp_runtime.call_tool(
+            "twelvedata_remote", tool_name, {"symbol": ticker}, agent_key="consultant"
+        )
+    except Exception as exc:
+        return json.dumps(
+            {"error": str(exc), "ticker": ticker, "query": query, "source": "twelvedata_mcp"}
+        )
+    return result_raw
+
+
 def get_consultant_tools() -> list:
     """Get the list of tools available to the External Consultant.
 
     DELIBERATELY excludes spot_check_metric (yfinance) because the main
     pipeline already uses yfinance — verifying yfinance against yfinance is
     circular validation. The consultant gets only independent sources:
-    - spot_check_metric_alt: FMP (independent of pipeline)
+    - spot_check_metric_alt: FMP REST (independent of pipeline)
     - get_official_filings: Official filing APIs (EDINET/DART) for ground-truth
+    - spot_check_metric_mcp_fmp: FMP via MCP (broader tool surface, same vendor)
+    - spot_check_price_or_indicator_mcp_twelvedata: Twelve Data via MCP (pinned endpoints)
     """
     from src.tools.research import get_official_filings
 
-    return [spot_check_metric_alt, get_official_filings]
+    tools: list = [
+        spot_check_metric_alt,
+        get_official_filings,
+    ]
+
+    try:
+        services = get_current_runtime_services()
+    except Exception:
+        services = None
+
+    if (
+        services is not None
+        and services.mcp_runtime is not None
+        and config.consultant_mcp_enabled
+    ):
+        tools.append(spot_check_metric_mcp_fmp)
+        tools.append(spot_check_price_or_indicator_mcp_twelvedata)
+
+    return tools

--- a/src/consultant_tools.py
+++ b/src/consultant_tools.py
@@ -15,16 +15,21 @@ Two spot-check tools:
 
 import asyncio
 import json
-from typing import Annotated
+from typing import Annotated, Any
 
 import structlog
 import yfinance as yf
 from langchain_core.tools import tool
 
-from src.error_safety import safe_error_payload, summarize_exception
 from src.config import config
+from src.error_safety import safe_error_payload, summarize_exception
+from src.mcp.errors import MCPCallError, make_mcp_tool_name
 from src.runtime_diagnostics import classify_failure
-from src.runtime_services import get_current_runtime_services
+from src.runtime_services import (
+    get_current_runtime_services,
+    get_current_tool_service,
+)
+from src.tooling.runtime import ToolInvocation, ToolResult
 
 logger = structlog.get_logger(__name__)
 
@@ -70,6 +75,39 @@ FMP_FIELD_MAP: dict[str, tuple[str, str]] = {
     "dividendYield": ("ratios", "dividendYield"),
 }
 
+FMP_MCP_REQUIRED_TOOLS = frozenset({"statements", "quote"})
+
+# Map yfinance-named metrics → (FMP MCP tool, endpoint enum value).
+# FMP MCP uses a dispatcher pattern: each tool takes an ``endpoint`` argument
+# that selects the actual operation. Verified empirically via tools/list.
+# TTM endpoints chosen for ratios/income/cash-flow because the consultant is
+# cross-validating the *current* state, not historical snapshots.
+_FMP_METRIC_DISPATCH: dict[str, tuple[str, str]] = {
+    "trailingPE": ("statements", "metrics-ratios-ttm"),
+    "forwardPE": ("statements", "metrics-ratios-ttm"),
+    "priceToBook": ("statements", "metrics-ratios-ttm"),
+    "debtToEquity": ("statements", "metrics-ratios-ttm"),
+    "returnOnEquity": ("statements", "metrics-ratios-ttm"),
+    "returnOnAssets": ("statements", "metrics-ratios-ttm"),
+    "operatingMargins": ("statements", "metrics-ratios-ttm"),
+    "dividendYield": ("statements", "metrics-ratios-ttm"),
+    "payoutRatio": ("statements", "metrics-ratios-ttm"),
+    "currentRatio": ("statements", "metrics-ratios-ttm"),
+    "freeCashflow": ("statements", "cashflow-statements-ttm"),
+    "operatingCashflow": ("statements", "cashflow-statements-ttm"),
+    "totalRevenue": ("statements", "income-statements-ttm"),
+    "netIncomeToCommon": ("statements", "income-statements-ttm"),
+    "currentPrice": ("quote", "quote"),
+    "marketCap": ("quote", "quote"),
+}
+
+
+def _fmp_mcp_field_for(metric: str) -> str:
+    """Return the response-field name to extract from the FMP MCP payload."""
+    if metric in FMP_FIELD_MAP:
+        return FMP_FIELD_MAP[metric][1]
+    return {"currentPrice": "price", "marketCap": "marketCap"}[metric]
+
 
 def _build_fmp_access_failure(
     *,
@@ -92,6 +130,161 @@ def _build_fmp_access_failure(
     if cooldown_until is not None:
         payload["cooldown_until"] = cooldown_until
     return json.dumps(payload)
+
+
+def _build_mcp_access_failure(
+    *,
+    ticker: str,
+    key: str,
+    lookup: str,
+    provider: str,
+    error: str,
+    failure_kind: str,
+    retryable: bool,
+    source: str,
+) -> str:
+    return json.dumps(
+        {
+            "error": error,
+            "ticker": ticker,
+            key: lookup,
+            "provider": provider,
+            "failure_kind": failure_kind,
+            "retryable": retryable,
+            "source": source,
+        }
+    )
+
+
+async def _execute_mcp_via_tool_service(
+    services: Any,
+    *,
+    server_id: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+    agent_key: str,
+    scope: str,
+) -> ToolResult:
+    """Route an MCP call through the active ToolExecutionService.
+
+    Returns the full ``ToolResult`` from the shared tool plane so caller-facing
+    wrappers can distinguish hook-level blocks and preserve structured findings
+    without bypassing the normal audit/inspection/budget chokepoint.
+    """
+    invocation = ToolInvocation(
+        name=make_mcp_tool_name(server_id, tool_name),
+        args=arguments,
+        source="consultant",
+        agent_key=agent_key,
+    )
+
+    async def runner(args: dict[str, Any]) -> Any:
+        return await services.mcp_runtime.execute_raw(
+            server_id,
+            tool_name,
+            args,
+            scope=scope,
+            agent_key=agent_key,
+        )
+
+    return await get_current_tool_service().execute(invocation, runner=runner)
+
+
+def _mcp_wrapper_available(
+    runtime: Any,
+    *,
+    server_id: str,
+    required_tools: frozenset[str],
+    scope: str = "consultant",
+) -> bool:
+    """Return whether a narrow MCP wrapper can be exposed safely."""
+    checker = getattr(runtime, "is_tool_available", None)
+    if checker is None:
+        return False
+    return all(
+        checker(server_id, tool_name, scope=scope) for tool_name in required_tools
+    )
+
+
+def _classify_mcp_blocked_result(result: ToolResult) -> tuple[str, str]:
+    """Map a blocked hook result onto a stable wrapper-facing failure shape."""
+    message = result.value if isinstance(result.value, str) else "TOOL_BLOCKED"
+    normalized = message.lower()
+    if "budget exhausted" in normalized:
+        return "budget", message
+    return "inspection_blocked", message
+
+
+def _build_mcp_text_payload(
+    *,
+    ticker: str,
+    key: str,
+    lookup: str,
+    provider: str,
+    source: str,
+    text_payload: str,
+) -> str:
+    return json.dumps(
+        {
+            "ticker": ticker,
+            key: lookup,
+            "provider": provider,
+            "source": source,
+            "text_payload": text_payload,
+            "note": "mcp_payload_sanitized_or_textual",
+        }
+    )
+
+
+def _extract_candidate_payloads(result: dict[str, Any]) -> list[Any]:
+    candidates: list[Any] = []
+    for key in ("structured_content", "parsed_text_json"):
+        value = result.get(key)
+        if value is not None:
+            candidates.append(value)
+    text_value = result.get("text_content")
+    if text_value:
+        candidates.append(text_value)
+    return candidates
+
+
+def _find_nested_value(payload: Any, field_name: str) -> Any | None:
+    if isinstance(payload, dict):
+        if field_name in payload:
+            return payload[field_name]
+        data = payload.get("data")
+        if data is not None:
+            found = _find_nested_value(data, field_name)
+            if found is not None:
+                return found
+        for value in payload.values():
+            found = _find_nested_value(value, field_name)
+            if found is not None:
+                return found
+    elif isinstance(payload, list):
+        for item in payload:
+            found = _find_nested_value(item, field_name)
+            if found is not None:
+                return found
+    return None
+
+
+def _find_period(payload: Any) -> str | None:
+    if isinstance(payload, dict):
+        period = payload.get("period")
+        if isinstance(period, str):
+            return period
+        data = payload.get("data")
+        if data is not None:
+            nested = _find_period(data)
+            if nested is not None:
+                return nested
+    elif isinstance(payload, list):
+        for item in payload:
+            nested = _find_period(item)
+            if nested is not None:
+                return nested
+    return None
 
 
 @tool("spot_check_metric")
@@ -331,81 +524,145 @@ async def spot_check_metric_mcp_fmp(
     Use when you suspect a specific number in the analyst reports is wrong
     or when DATA_BLOCK and narrative claims diverge.
     """
-    _METRIC_TO_MCP_TOOL = {
-        "trailingPE": "ratios",
-        "forwardPE": "ratios",
-        "priceToBook": "ratios",
-        "debtToEquity": "ratios",
-        "returnOnEquity": "ratios",
-        "returnOnAssets": "ratios",
-        "operatingMargins": "ratios",
-        "dividendYield": "ratios",
-        "payoutRatio": "ratios",
-        "currentRatio": "ratios",
-        "freeCashflow": "cash-flow-statement",
-        "operatingCashflow": "cash-flow-statement",
-        "totalRevenue": "income-statement",
-        "netIncomeToCommon": "income-statement",
-        "currentPrice": "quote",
-        "marketCap": "quote",
-    }
+    if metric not in _FMP_METRIC_DISPATCH:
+        return json.dumps(
+            {
+                "error": f"Metric '{metric}' not available via FMP MCP spot-check",
+                "available_metrics": sorted(_FMP_METRIC_DISPATCH.keys()),
+                "provider": "fmp",
+                "source": "fmp_mcp",
+            }
+        )
 
-    tool_name = _METRIC_TO_MCP_TOOL.get(metric, "ratios")
     services = get_current_runtime_services()
     if services is None or services.mcp_runtime is None:
-        return json.dumps({"error": "mcp_not_available", "ticker": ticker, "metric": metric})
+        return _build_mcp_access_failure(
+            ticker=ticker,
+            key="metric",
+            lookup=metric,
+            provider="fmp",
+            error="FMP MCP is not available in the current runtime",
+            failure_kind="config_error",
+            retryable=False,
+            source="fmp_mcp",
+        )
+
+    tool_name, endpoint = _FMP_METRIC_DISPATCH[metric]
+    metric_field = _fmp_mcp_field_for(metric)
 
     try:
-        result_raw = await services.mcp_runtime.call_tool(
-            "fmp_remote", tool_name, {"symbol": ticker}, agent_key="consultant"
+        result = await _execute_mcp_via_tool_service(
+            services,
+            server_id="fmp_remote",
+            tool_name=tool_name,
+            arguments={"symbol": ticker, "endpoint": endpoint},
+            agent_key="consultant",
+            scope="consultant",
+        )
+    except MCPCallError as exc:
+        return _build_mcp_access_failure(
+            ticker=ticker,
+            key="metric",
+            lookup=metric,
+            provider="fmp",
+            error=exc.message,
+            failure_kind=exc.category.value,
+            retryable=exc.retryable,
+            source="fmp_mcp",
         )
     except Exception as exc:
-        return json.dumps({"error": str(exc), "ticker": ticker, "metric": metric, "source": "fmp_mcp"})
-
-    try:
-        data = json.loads(result_raw)
-        payload = data.get("result") if isinstance(data, dict) else data
-        if isinstance(payload, dict):
-            value = payload.get(metric)
-            return json.dumps(
-                {"ticker": ticker, "metric": metric, "value": value, "source": "fmp_mcp"}
+        return json.dumps(
+            safe_error_payload(
+                exc,
+                operation="spot_check_metric_mcp_fmp",
+                provider="unknown",
+                extra={
+                    "ticker": ticker,
+                    "metric": metric,
+                    "provider": "fmp",
+                    "source": "fmp_mcp",
+                },
             )
-    except Exception:
-        pass
-    return result_raw
-
-
-@tool("spot_check_price_or_indicator_mcp_twelvedata")
-async def spot_check_price_or_indicator_mcp_twelvedata(
-    ticker: Annotated[str, "Stock ticker (e.g., 7203.T, 0005.HK)"],
-    query: Annotated[
-        str, "One of 'price', 'volume', 'rsi', 'macd', or 'quote'"
-    ],
-) -> str:
-    """Fetch price / volume / technical indicator from **Twelve Data MCP**.
-
-    Use only to verify a specific quote or indicator when the main pipeline
-    and FMP disagree.  Never enable the “u‑tool” for consultant checks.
-
-    Returns compact JSON.
-    """
-    services = get_current_runtime_services()
-    if services is None or services.mcp_runtime is None:
-        return json.dumps(
-            {"error": "mcp_not_available", "ticker": ticker, "query": query}
         )
 
-    allowed_tools = {"price", "quote"}
-    tool_name = query if query in allowed_tools else "quote"
-    try:
-        result_raw = await services.mcp_runtime.call_tool(
-            "twelvedata_remote", tool_name, {"symbol": ticker}, agent_key="consultant"
+    if result.blocked:
+        failure_kind, error = _classify_mcp_blocked_result(result)
+        return _build_mcp_access_failure(
+            ticker=ticker,
+            key="metric",
+            lookup=metric,
+            provider="fmp",
+            error=error,
+            failure_kind=failure_kind,
+            retryable=False,
+            source="fmp_mcp",
         )
-    except Exception as exc:
-        return json.dumps(
-            {"error": str(exc), "ticker": ticker, "query": query, "source": "twelvedata_mcp"}
+
+    value = result.value
+    if isinstance(value, str):
+        return _build_mcp_text_payload(
+            ticker=ticker,
+            key="metric",
+            lookup=metric,
+            provider="fmp",
+            source="fmp_mcp",
+            text_payload=value,
         )
-    return result_raw
+    if not isinstance(value, dict):
+        return _build_mcp_access_failure(
+            ticker=ticker,
+            key="metric",
+            lookup=metric,
+            provider="fmp",
+            error="unexpected_mcp_payload_shape",
+            failure_kind="protocol",
+            retryable=False,
+            source="fmp_mcp",
+        )
+
+    # Vendor-side error (isError=true on CallToolResult): surface text_content
+    # as the error rather than falling through to opaque shape-extraction failure.
+    if value.get("is_error"):
+        return _build_mcp_access_failure(
+            ticker=ticker,
+            key="metric",
+            lookup=metric,
+            provider="fmp",
+            error=str(value.get("text_content") or "MCP tool returned isError=true"),
+            failure_kind="tool_error",
+            retryable=False,
+            source="fmp_mcp",
+        )
+
+    normalized_payload = value
+    for payload in _extract_candidate_payloads(normalized_payload):
+        extracted = _find_nested_value(payload, metric_field)
+        if extracted is not None:
+            response = {
+                "ticker": ticker,
+                "metric": metric,
+                "value": extracted,
+                "provider": "fmp",
+                "source": "fmp_mcp",
+                "mcp_tool": tool_name,
+                "mcp_endpoint": endpoint,
+            }
+            period = _find_period(payload)
+            if period is not None:
+                response["period"] = period
+            return json.dumps(response)
+
+    return json.dumps(
+        {
+            "error": "unexpected_mcp_payload_shape",
+            "ticker": ticker,
+            "metric": metric,
+            "provider": "fmp",
+            "source": "fmp_mcp",
+            "mcp_tool": tool_name,
+            "mcp_endpoint": endpoint,
+        }
+    )
 
 
 def get_consultant_tools() -> list:
@@ -417,7 +674,10 @@ def get_consultant_tools() -> list:
     - spot_check_metric_alt: FMP REST (independent of pipeline)
     - get_official_filings: Official filing APIs (EDINET/DART) for ground-truth
     - spot_check_metric_mcp_fmp: FMP via MCP (broader tool surface, same vendor)
-    - spot_check_price_or_indicator_mcp_twelvedata: Twelve Data via MCP (pinned endpoints)
+
+    Twelve Data MCP is intentionally not exposed: their public MCP server only
+    publishes ``u-tool`` (a free-form AI router) and ``doc-tool`` — neither
+    fits the consultant's narrow-allowlist + structured-payload contract.
     """
     from src.tools.research import get_official_filings
 
@@ -436,7 +696,12 @@ def get_consultant_tools() -> list:
         and services.mcp_runtime is not None
         and config.consultant_mcp_enabled
     ):
-        tools.append(spot_check_metric_mcp_fmp)
-        tools.append(spot_check_price_or_indicator_mcp_twelvedata)
+        runtime = services.mcp_runtime
+        if _mcp_wrapper_available(
+            runtime,
+            server_id="fmp_remote",
+            required_tools=FMP_MCP_REQUIRED_TOOLS,
+        ):
+            tools.append(spot_check_metric_mcp_fmp)
 
     return tools

--- a/src/data/fetcher.py
+++ b/src/data/fetcher.py
@@ -1722,10 +1722,17 @@ class SmartMarketDataFetcher(FinancialFetcher):
             self._get_financial_metrics_uncached(ticker, timeout)
         )
         self._metrics_inflight[ticker] = task
-        try:
-            result = await task
-        finally:
-            self._metrics_inflight.pop(ticker, None)
+
+        # Clear the dedup slot the moment the task ends (success, exception, or
+        # cancellation) — independent of whether anyone is still awaiting it.
+        # A try/finally around ``await task`` would only run if the awaiter
+        # itself returns; if a hung blocking thread keeps the task pending,
+        # try/finally would leak the slot indefinitely.
+        def _clear_metrics_slot(_t: asyncio.Task[Any], key: str = ticker) -> None:
+            self._metrics_inflight.pop(key, None)
+
+        task.add_done_callback(_clear_metrics_slot)
+        result = await task
 
         self._set_cached_metrics(ticker, result)
         return copy.deepcopy(result)
@@ -1817,10 +1824,15 @@ class SmartMarketDataFetcher(FinancialFetcher):
             )
         )
         self._history_inflight[key] = task
-        try:
-            hist = await task
-        finally:
-            self._history_inflight.pop(key, None)
+        history_key = key  # bind for the closure below
+
+        # See _metrics_inflight cleanup note: clear via done-callback so a
+        # hung underlying fetch cannot leak the dedup slot.
+        def _clear_history_slot(_t: asyncio.Task[Any]) -> None:
+            self._history_inflight.pop(history_key, None)
+
+        task.add_done_callback(_clear_history_slot)
+        hist = await task
 
         self._set_cached_history(
             ticker,

--- a/src/data/source_fetchers.py
+++ b/src/data/source_fetchers.py
@@ -238,58 +238,74 @@ async def fetch_all_sources_parallel(
     logger_obj: Any = logger,
     asyncio_module: Any = asyncio,
 ) -> dict[str, dict | None]:
-    """Launch all configured sources in parallel and collect outcomes."""
+    """Launch all configured sources concurrently and collect outcomes.
+
+    Each source has a hard per-source timeout that orphans the underlying
+    task if it exceeds the deadline (see ``run_with_hard_timeout``); slow or
+    hung providers cannot block sibling providers or the caller's wall clock
+    beyond ``per_source_timeout``.
+    """
+    from src.async_utils import run_with_hard_timeout
+
     logger_obj.info("launching_parallel_sources", symbol=symbol)
-    tasks = {
-        "yfinance": fetcher._fetch_yfinance_enhanced(symbol),
-        "yahooquery": asyncio_module.to_thread(
+    builders = {
+        "yfinance": lambda: fetcher._fetch_yfinance_enhanced(symbol),
+        "yahooquery": lambda: asyncio_module.to_thread(
             fetcher._fetch_yahooquery_fallback, symbol
         ),
-        "fmp": fetcher._fetch_fmp_fallback(symbol),
-        "eodhd": fetcher._fetch_eodhd_fallback(symbol),
-        "alpha_vantage": fetcher._fetch_av_fallback(symbol),
+        "fmp": lambda: fetcher._fetch_fmp_fallback(symbol),
+        "eodhd": lambda: fetcher._fetch_eodhd_fallback(symbol),
+        "alpha_vantage": lambda: fetcher._fetch_av_fallback(symbol),
     }
 
-    results: dict[str, dict | None] = {}
-    source_outcomes: dict[str, str] = {}
-    for source_name, coro in tasks.items():
+    async def _run_one(name: str) -> tuple[str, dict | None, str]:
         try:
-            result = await asyncio_module.wait_for(coro, timeout=per_source_timeout)
-            results[source_name] = result
-            if result:
-                source_outcomes[source_name] = "success"
-                logger_obj.info(
-                    f"{source_name}_success", symbol=symbol, fields=len(result)
-                )
-            else:
-                source_outcomes[source_name] = "empty"
-                logger_obj.debug(f"{source_name}_returned_none", symbol=symbol)
+            result = await run_with_hard_timeout(
+                builders[name](),
+                timeout=per_source_timeout,
+                label=f"data_source:{name}:{symbol}",
+            )
         except asyncio_module.TimeoutError:
             logger_obj.warning(
-                f"{source_name}_timeout",
+                f"{name}_timeout",
                 symbol=symbol,
                 timeout_seconds=per_source_timeout,
             )
-            results[source_name] = None
-            source_outcomes[source_name] = "timeout"
+            return name, None, "timeout"
         except Exception as exc:
             logger_obj.warning(
-                f"{source_name}_error",
+                f"{name}_error",
                 symbol=symbol,
                 **summarize_exception(
                     exc,
-                    operation=f"fetching {source_name} data",
+                    operation=f"fetching {name} data",
                     provider="unknown",
                 ),
             )
-            results[source_name] = None
-            source_outcomes[source_name] = f"error:{type(exc).__name__}"
+            return name, None, f"error:{type(exc).__name__}"
+
+        if result:
+            logger_obj.info(f"{name}_success", symbol=symbol, fields=len(result))
+            return name, result, "success"
+        logger_obj.debug(f"{name}_returned_none", symbol=symbol)
+        return name, None, "empty"
+
+    completed = await asyncio_module.gather(
+        *(_run_one(name) for name in builders),
+        return_exceptions=False,
+    )
+
+    results: dict[str, dict | None] = {}
+    source_outcomes: dict[str, str] = {}
+    for name, result, outcome in completed:
+        results[name] = result
+        source_outcomes[name] = outcome
 
     if not [source for source, result in results.items() if result is not None]:
         logger_obj.warning(
             "all_data_sources_failed",
             symbol=symbol,
-            sources_attempted=list(tasks.keys()),
+            sources_attempted=list(builders.keys()),
             source_outcomes=source_outcomes,
             suspected_cause=classify_aggregate_source_failure(source_outcomes),
         )

--- a/src/main.py
+++ b/src/main.py
@@ -1110,6 +1110,11 @@ async def run_with_args(
     capture_preflight_override: BaselinePreflightResult | None = None,
 ) -> int:
     """Run the analysis CLI flow for already-parsed arguments."""
+    from src.async_utils import install_pending_task_dump_handler
+
+    # `kill -USR1 <pid>` will dump every pending asyncio task with stack so
+    # operators can diagnose hangs without restarting the process.
+    _uninstall_dump_handler = install_pending_task_dump_handler()
     try:
         _apply_runtime_overrides(args)
         cli._validate_cli_args(args)
@@ -1318,6 +1323,10 @@ async def run_with_args(
             from src.cleanup import cleanup_async_resources
 
             await cleanup_async_resources()
+        except Exception:
+            pass
+        try:
+            _uninstall_dump_handler()
         except Exception:
             pass
 

--- a/src/mcp/auth.py
+++ b/src/mcp/auth.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass, field
-from typing import Any
 
+from src.config import get_env_value
 from src.mcp.config import MCPServerSpec
 
 
@@ -12,7 +11,8 @@ class MCPResolvedServer:
     server_id: str
     url: str | None = None
     headers: dict[str, str] = field(default_factory=dict)
-    stdio_env: dict[str, str] | None = None
+    stdio_env: dict[str, str] = field(default_factory=dict)
+    cwd: str | None = None
 
 
 def resolve_auth(spec: MCPServerSpec) -> MCPResolvedServer | None:
@@ -21,18 +21,28 @@ def resolve_auth(spec: MCPServerSpec) -> MCPResolvedServer | None:
 
     url = spec.base_url
     headers: dict[str, str] = {}
+    stdio_env: dict[str, str] = {}
 
-    if spec.auth and spec.auth.type != "none":
-        env_name = spec.auth.env_var
-        if not env_name:
+    # Use get_env_value() so MCP keys defined only in .env are visible — the
+    # repo's pydantic Settings does not reflect arbitrary keys to os.environ.
+    for env_name in spec.env_vars:
+        value = get_env_value(env_name)
+        if value:
+            stdio_env[env_name] = value
+
+    if spec.auth is not None and spec.auth.type != "none":
+        auth_env_name = spec.auth.env_var
+        if not auth_env_name:
             raise ValueError(
                 f"Server {spec.id} auth requires an 'env_var' in auth config."
             )
-        key = os.getenv(env_name)
+        key = get_env_value(auth_env_name)
         if not key:
             raise ValueError(
-                f"Required env var {env_name!r} not set for MCP server {spec.id}"
+                f"Required env var {auth_env_name!r} not set for MCP server {spec.id}"
             )
+        if spec.transport == "stdio":
+            stdio_env[auth_env_name] = key
 
         if spec.auth.type == "query_api_key":
             param = spec.auth.param or "apikey"
@@ -48,4 +58,6 @@ def resolve_auth(spec: MCPServerSpec) -> MCPResolvedServer | None:
         server_id=spec.id,
         url=url,
         headers=headers,
+        stdio_env=stdio_env,
+        cwd=spec.cwd,
     )

--- a/src/mcp/auth.py
+++ b/src/mcp/auth.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from src.mcp.config import MCPServerSpec
+
+
+@dataclass(frozen=True)
+class MCPResolvedServer:
+    server_id: str
+    url: str | None = None
+    headers: dict[str, str] = field(default_factory=dict)
+    stdio_env: dict[str, str] | None = None
+
+
+def resolve_auth(spec: MCPServerSpec) -> MCPResolvedServer | None:
+    if not spec.enabled:
+        return None
+
+    url = spec.base_url
+    headers: dict[str, str] = {}
+
+    if spec.auth and spec.auth.type != "none":
+        env_name = spec.auth.env_var
+        if not env_name:
+            raise ValueError(
+                f"Server {spec.id} auth requires an 'env_var' in auth config."
+            )
+        key = os.getenv(env_name)
+        if not key:
+            raise ValueError(
+                f"Required env var {env_name!r} not set for MCP server {spec.id}"
+            )
+
+        if spec.auth.type == "query_api_key":
+            param = spec.auth.param or "apikey"
+            separator = "&" if "?" in (url or "") else "?"
+            url = f"{url}{separator}{param}={key}"
+        elif spec.auth.type == "header_bearer":
+            headers["Authorization"] = f"Bearer {key}"
+        elif spec.auth.type == "header_static":
+            header_name = spec.auth.param or "X-API-Key"
+            headers[header_name] = key
+
+    return MCPResolvedServer(
+        server_id=spec.id,
+        url=url,
+        headers=headers,
+    )

--- a/src/mcp/budget.py
+++ b/src/mcp/budget.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import datetime
+import sqlite3
+from pathlib import Path
+
+from src.mcp.config import MCPServerSpec
+
+
+class BudgetTracker:
+    """Daily and per‑run call limits using a local SQLite database."""
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._init_db()
+        self._run_calls: dict[str, int] = {}
+
+    def _init_db(self) -> None:
+        conn = sqlite3.connect(self._db_path)
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS mcp_usage (
+                usage_day TEXT NOT NULL,
+                server_id TEXT NOT NULL,
+                call_count INTEGER NOT NULL DEFAULT 0,
+                PRIMARY KEY (usage_day, server_id)
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+    def can_call(self, server_id: str, spec: MCPServerSpec) -> bool:
+        """Return True if the daily and per‑run budgets are not yet exhausted."""
+        today = datetime.date.today().isoformat()
+        conn = sqlite3.connect(self._db_path)
+        cur = conn.execute(
+            "SELECT call_count FROM mcp_usage WHERE usage_day=? AND server_id=?",
+            (today, server_id),
+        )
+        row = cur.fetchone()
+        conn.close()
+        daily = row[0] if row else 0
+
+        run = self._run_calls.get(server_id, 0)
+
+        if spec.daily_call_limit > 0 and daily >= spec.daily_call_limit:
+            return False
+        if spec.per_run_limit > 0 and run >= spec.per_run_limit:
+            return False
+        return True
+
+    def record_call(self, server_id: str) -> None:
+        today = datetime.date.today().isoformat()
+        conn = sqlite3.connect(self._db_path)
+        conn.execute(
+            """
+            INSERT INTO mcp_usage (usage_day, server_id, call_count)
+            VALUES (?, ?, 1)
+            ON CONFLICT(usage_day, server_id)
+            DO UPDATE SET call_count = call_count + 1
+            """,
+            (today, server_id),
+        )
+        conn.commit()
+        conn.close()
+        self._run_calls[server_id] = self._run_calls.get(server_id, 0) + 1

--- a/src/mcp/budget.py
+++ b/src/mcp/budget.py
@@ -1,47 +1,63 @@
 from __future__ import annotations
 
-import datetime
+import datetime as dt
 import sqlite3
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+import structlog
 
 from src.mcp.config import MCPServerSpec
+from src.mcp.errors import parse_mcp_tool_name
+from src.tooling.runtime import ToolCallBlocked, ToolInvocation, ToolResult
+
+if TYPE_CHECKING:
+    from src.mcp.client import MCPRuntime
+
+logger = structlog.get_logger(__name__)
 
 
 class BudgetTracker:
-    """Daily and per‑run call limits using a local SQLite database."""
+    """Daily and per-run call limits backed by a local SQLite database."""
 
-    def __init__(self, db_path: str) -> None:
-        self._db_path = db_path
-        self._init_db()
+    def __init__(self, db_path: str, *, retention_days: int = 7) -> None:
+        self._db_path = Path(db_path)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._retention_days = retention_days
         self._run_calls: dict[str, int] = {}
+        self._init_db()
+        self._cleanup_old_rows()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self._db_path)
 
     def _init_db(self) -> None:
-        conn = sqlite3.connect(self._db_path)
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS mcp_usage (
-                usage_day TEXT NOT NULL,
-                server_id TEXT NOT NULL,
-                call_count INTEGER NOT NULL DEFAULT 0,
-                PRIMARY KEY (usage_day, server_id)
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mcp_usage (
+                    usage_day TEXT NOT NULL,
+                    server_id TEXT NOT NULL,
+                    call_count INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (usage_day, server_id)
+                )
+                """
             )
-            """
-        )
-        conn.commit()
-        conn.close()
+
+    def _cleanup_old_rows(self) -> None:
+        cutoff = (dt.date.today() - dt.timedelta(days=self._retention_days)).isoformat()
+        with self._connect() as conn:
+            conn.execute("DELETE FROM mcp_usage WHERE usage_day < ?", (cutoff,))
 
     def can_call(self, server_id: str, spec: MCPServerSpec) -> bool:
-        """Return True if the daily and per‑run budgets are not yet exhausted."""
-        today = datetime.date.today().isoformat()
-        conn = sqlite3.connect(self._db_path)
-        cur = conn.execute(
-            "SELECT call_count FROM mcp_usage WHERE usage_day=? AND server_id=?",
-            (today, server_id),
-        )
-        row = cur.fetchone()
-        conn.close()
-        daily = row[0] if row else 0
+        today = dt.date.today().isoformat()
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT call_count FROM mcp_usage WHERE usage_day=? AND server_id=?",
+                (today, server_id),
+            ).fetchone()
 
+        daily = row[0] if row else 0
         run = self._run_calls.get(server_id, 0)
 
         if spec.daily_call_limit > 0 and daily >= spec.daily_call_limit:
@@ -50,18 +66,64 @@ class BudgetTracker:
             return False
         return True
 
-    def record_call(self, server_id: str) -> None:
-        today = datetime.date.today().isoformat()
-        conn = sqlite3.connect(self._db_path)
-        conn.execute(
-            """
-            INSERT INTO mcp_usage (usage_day, server_id, call_count)
-            VALUES (?, ?, 1)
-            ON CONFLICT(usage_day, server_id)
-            DO UPDATE SET call_count = call_count + 1
-            """,
-            (today, server_id),
-        )
-        conn.commit()
-        conn.close()
+    def record_upstream_consumption(self, server_id: str) -> None:
+        today = dt.date.today().isoformat()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO mcp_usage (usage_day, server_id, call_count)
+                VALUES (?, ?, 1)
+                ON CONFLICT(usage_day, server_id)
+                DO UPDATE SET call_count = call_count + 1
+                """,
+                (today, server_id),
+            )
         self._run_calls[server_id] = self._run_calls.get(server_id, 0) + 1
+
+
+class MCPBudgetHook:
+    """Tool-execution-service hook that enforces MCP budgets uniformly.
+
+    Recognizes invocations whose name matches ``mcp__<server>__<tool>``.
+    ``before()`` blocks the call when the per-run or per-day limit is
+    exhausted; ``after()`` increments the counter for any non-blocked result
+    (including upstream ``isError=true`` payloads, which still consume
+    upstream quota).
+
+    Wire alongside :class:`ContentInspectionHook` on the shared
+    :class:`ToolExecutionService` so audit, argument policy, content
+    inspection, and budget all observe MCP calls from a single chokepoint.
+    """
+
+    def __init__(self, runtime: MCPRuntime) -> None:
+        self._runtime = runtime
+
+    async def before(self, call: ToolInvocation) -> ToolInvocation:
+        parsed = parse_mcp_tool_name(call.name)
+        if parsed is None:
+            return call
+        server_id, _ = parsed
+        spec = self._runtime.specs.get(server_id)
+        if spec is None:
+            return call
+        if not self._runtime.budget.can_call(server_id, spec):
+            logger.warning(
+                "mcp_budget_exhausted",
+                server_id=server_id,
+                tool=call.name,
+                agent_key=call.agent_key,
+            )
+            raise ToolCallBlocked(f"MCP budget exhausted for {server_id}")
+        return call
+
+    async def after(self, call: ToolInvocation, result: ToolResult) -> ToolResult:
+        parsed = parse_mcp_tool_name(call.name)
+        if parsed is None:
+            return result
+        if result.blocked:
+            return result
+        server_id, _ = parsed
+        if server_id not in self._runtime.specs:
+            return result
+        self._runtime.budget.record_upstream_consumption(server_id)
+        return result

--- a/src/mcp/catalog.py
+++ b/src/mcp/catalog.py
@@ -1,26 +1,35 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 
+@dataclass(frozen=True)
+class ToolDescriptor:
+    server_id: str
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    output_schema: dict[str, Any] | None = None
+
+
 class ToolCatalog:
-    """In-memory tool catalog per MCP server, filtered by allowlists."""
+    """In-memory MCP tool catalog keyed by server id."""
 
     def __init__(self) -> None:
-        self._tools: dict[str, list[dict[str, Any]]] = {}
+        self._tools: dict[str, list[ToolDescriptor]] = {}
 
-    def update(self, server_id: str, tools: list[dict[str, Any]]) -> None:
+    def update(self, server_id: str, tools: list[ToolDescriptor]) -> None:
         self._tools[server_id] = tools
 
-    def search(self, server_id: str, allowlist: list[str]) -> list[dict[str, Any]]:
+    def list_for_server(
+        self,
+        server_id: str,
+        *,
+        allowlist: list[str] | None = None,
+    ) -> list[ToolDescriptor]:
         tools = self._tools.get(server_id, [])
-        if allowlist:
-            names = set(allowlist)
-            return [t for t in tools if t.get("name") in names]
-        return tools
-
-    def detail(self, server_id: str, tool_name: str) -> dict[str, Any] | None:
-        for t in self._tools.get(server_id, []):
-            if t.get("name") == tool_name:
-                return t
-        return None
+        if not allowlist:
+            return list(tools)
+        allowed = set(allowlist)
+        return [tool for tool in tools if tool.name in allowed]

--- a/src/mcp/catalog.py
+++ b/src/mcp/catalog.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class ToolCatalog:
+    """In-memory tool catalog per MCP server, filtered by allowlists."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, list[dict[str, Any]]] = {}
+
+    def update(self, server_id: str, tools: list[dict[str, Any]]) -> None:
+        self._tools[server_id] = tools
+
+    def search(self, server_id: str, allowlist: list[str]) -> list[dict[str, Any]]:
+        tools = self._tools.get(server_id, [])
+        if allowlist:
+            names = set(allowlist)
+            return [t for t in tools if t.get("name") in names]
+        return tools
+
+    def detail(self, server_id: str, tool_name: str) -> dict[str, Any] | None:
+        for t in self._tools.get(server_id, []):
+            if t.get("name") == tool_name:
+                return t
+        return None

--- a/src/mcp/client.py
+++ b/src/mcp/client.py
@@ -1,43 +1,315 @@
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import json
-import logging
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator
+from typing import Any
+
+import httpx
 
 from mcp import ClientSession
+from mcp.client.stdio import StdioServerParameters, stdio_client
 from mcp.client.streamable_http import streamable_http_client
-from mcp.types import CallToolResult
-
+from mcp.types import CallToolResult, ListToolsResult
 from src.mcp.auth import MCPResolvedServer, resolve_auth
 from src.mcp.budget import BudgetTracker
-from src.mcp.catalog import ToolCatalog
+from src.mcp.catalog import ToolCatalog, ToolDescriptor
 from src.mcp.config import MCPServerSpec
-from src.mcp.errors import MCPCallError
+from src.mcp.errors import (
+    MCPCallError,
+    MCPErrorCategory,
+    classify_mcp_error,
+)
 from src.mcp.normalize import normalize_result
 from src.tooling.inspection_service import INSPECTION_SERVICE
 from src.tooling.inspector import InspectionDecision, InspectionEnvelope, SourceKind
 
-logger = logging.getLogger(__name__)
+_DEFAULT_AUTH_COOLDOWN_SECONDS = 300
+_DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS = 30
+_MAX_RETRY_ATTEMPTS = 2
+_MAX_BACKOFF_SECONDS = 5.0
 
 
 class MCPRuntime:
-    """Runs MCP tool calls against configured servers, with inspection and budgeting."""
+    """Run MCP tool calls against configured servers with inspection and budgeting."""
 
     def __init__(self, servers: list[MCPServerSpec], budget_db_path: str) -> None:
-        self._specs = {s.id: s for s in servers}
+        self._specs = {spec.id: spec for spec in servers}
         self._resolved: dict[str, MCPResolvedServer] = {}
-        for s in servers:
-            resolved = resolve_auth(s)
+        for spec in servers:
+            resolved = resolve_auth(spec)
             if resolved is not None:
-                self._resolved[s.id] = resolved
+                self._resolved[spec.id] = resolved
 
         self._catalog = ToolCatalog()
         self._budget = BudgetTracker(budget_db_path)
         self._inspection_service = INSPECTION_SERVICE
+        self._cooldowns: dict[str, dt.datetime] = {}
 
-    # ------------------------------------------------------------------
+    @property
+    def specs(self) -> dict[str, MCPServerSpec]:
+        return dict(self._specs)
+
+    @property
+    def budget(self) -> BudgetTracker:
+        return self._budget
+
+    def _get_spec(self, server_id: str) -> MCPServerSpec:
+        try:
+            return self._specs[server_id]
+        except KeyError as exc:
+            raise MCPCallError(
+                message=f"MCP server {server_id} is not configured",
+                category=MCPErrorCategory.CONFIG,
+                server_id=server_id,
+            ) from exc
+
+    def _check_cooldown(self, spec: MCPServerSpec) -> None:
+        cooldown = self._cooldowns.get(spec.id)
+        if cooldown is None:
+            return
+        now = dt.datetime.now(dt.UTC)
+        if now >= cooldown:
+            self._cooldowns.pop(spec.id, None)
+            return
+        remaining = max(int((cooldown - now).total_seconds()), 1)
+        raise MCPCallError(
+            message=f"MCP server {spec.id} is in cooldown for {remaining}s",
+            category=MCPErrorCategory.TRANSPORT,
+            server_id=spec.id,
+            retryable=True,
+            retry_after_seconds=remaining,
+        )
+
+    def _register_cooldown(self, server_id: str, *, duration_seconds: int) -> None:
+        if duration_seconds <= 0:
+            return
+        until = dt.datetime.now(dt.UTC) + dt.timedelta(seconds=duration_seconds)
+        existing = self._cooldowns.get(server_id)
+        if existing is None or until > existing:
+            self._cooldowns[server_id] = until
+
+    def _require_access(self, spec: MCPServerSpec, *, scope: str | None) -> None:
+        if not spec.enabled:
+            raise MCPCallError(
+                message=f"MCP server {spec.id} is disabled",
+                category=MCPErrorCategory.CONFIG,
+                server_id=spec.id,
+            )
+        if not spec.supports_scope(scope):
+            raise MCPCallError(
+                message=f"MCP server {spec.id} is not available for scope {scope!r}",
+                category=MCPErrorCategory.CONFIG,
+                server_id=spec.id,
+            )
+        self._check_cooldown(spec)
+
+    def _require_tool_allowed(self, spec: MCPServerSpec, tool_name: str) -> None:
+        if spec.tool_allowlist and tool_name not in set(spec.tool_allowlist):
+            raise MCPCallError(
+                message=f"MCP tool {tool_name!r} is not allowlisted for {spec.id}",
+                category=MCPErrorCategory.CONFIG,
+                server_id=spec.id,
+                tool_name=tool_name,
+            )
+
+    def is_tool_available(
+        self,
+        server_id: str,
+        tool_name: str,
+        *,
+        scope: str | None = None,
+    ) -> bool:
+        """Return whether a server/tool is configured for a given agent scope.
+
+        This check intentionally ignores transient cooldown state so tool
+        exposure does not flap during short-lived vendor throttles.
+        """
+        spec = self._specs.get(server_id)
+        if spec is None or not spec.enabled:
+            return False
+        if not spec.supports_scope(scope):
+            return False
+        if spec.tool_allowlist and tool_name not in set(spec.tool_allowlist):
+            return False
+        return True
+
+    @asynccontextmanager
+    async def _open_session(self, spec: MCPServerSpec):
+        resolved = self._resolved.get(spec.id)
+        if resolved is None:
+            raise MCPCallError(
+                message=f"MCP server {spec.id} is enabled in config but could not be resolved",
+                category=MCPErrorCategory.CONFIG,
+                server_id=spec.id,
+            )
+
+        try:
+            if spec.transport == "streamable_http":
+                if resolved.url is None:
+                    raise MCPCallError(
+                        message=f"MCP server {spec.id} has no streamable HTTP URL",
+                        category=MCPErrorCategory.CONFIG,
+                        server_id=spec.id,
+                    )
+                async with httpx.AsyncClient(
+                    headers=resolved.headers or None,
+                    follow_redirects=True,
+                ) as http_client:
+                    async with streamable_http_client(
+                        resolved.url,
+                        http_client=http_client,
+                    ) as (read, write, _):
+                        async with ClientSession(read, write) as session:
+                            await session.initialize()
+                            yield session
+                return
+
+            params = StdioServerParameters(
+                command=spec.command or "",
+                args=spec.args,
+                env=resolved.stdio_env or None,
+                cwd=resolved.cwd,
+            )
+            async with stdio_client(params) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    yield session
+        except MCPCallError:
+            raise
+        except Exception as exc:
+            raise classify_mcp_error(exc, server_id=spec.id) from exc
+
+    def _on_call_failure(self, err: MCPCallError) -> None:
+        if err.category is MCPErrorCategory.AUTH:
+            self._register_cooldown(
+                err.server_id,
+                duration_seconds=_DEFAULT_AUTH_COOLDOWN_SECONDS,
+            )
+        elif err.category is MCPErrorCategory.TRANSPORT and err.http_status == 429:
+            duration = err.retry_after_seconds or _DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS
+            self._register_cooldown(err.server_id, duration_seconds=duration)
+
+    async def _execute_with_retry(
+        self,
+        spec: MCPServerSpec,
+        tool_name: str,
+        arguments: dict[str, Any],
+    ) -> CallToolResult:
+        last_err: MCPCallError | None = None
+        for attempt in range(_MAX_RETRY_ATTEMPTS):
+            try:
+                async with self._open_session(spec) as session:
+                    result: CallToolResult = await session.call_tool(
+                        tool_name, arguments
+                    )
+                    return result
+            except MCPCallError as err:
+                last_err = err
+            except Exception as exc:
+                last_err = classify_mcp_error(
+                    exc, server_id=spec.id, tool_name=tool_name
+                )
+
+            if last_err is None:  # pragma: no cover - belt-and-braces
+                raise RuntimeError("unreachable retry state")
+
+            is_last_attempt = attempt + 1 >= _MAX_RETRY_ATTEMPTS
+            if not last_err.retryable or is_last_attempt:
+                self._on_call_failure(last_err)
+                raise last_err
+
+            backoff = (
+                last_err.retry_after_seconds
+                if last_err.retry_after_seconds is not None
+                else 0.5 * (2**attempt)
+            )
+            await asyncio.sleep(min(float(backoff), _MAX_BACKOFF_SECONDS))
+
+        if last_err is not None:  # pragma: no cover - safety
+            raise last_err
+        raise RuntimeError("unreachable retry exit")
+
+    async def _inspect(
+        self,
+        normalized: dict[str, Any],
+        *,
+        spec: MCPServerSpec,
+        tool_name: str,
+        agent_key: str | None,
+    ) -> tuple[InspectionDecision, Any]:
+        envelope = InspectionEnvelope(
+            content_text=json.dumps(normalized, default=str),
+            raw_content=normalized,
+            source_kind=SourceKind.mcp_tool_output,
+            source_name=spec.id,
+            tool_name=tool_name,
+            agent_key=agent_key,
+            metadata={
+                "transport": spec.transport,
+                "trust_tier": spec.trust_tier,
+                "payload_profile": normalized.get("payload_profile", "free_text"),
+            },
+        )
+        return await self._inspection_service.evaluate(envelope)
+
+    async def list_tools_for_scope(self, scope: str) -> list[ToolDescriptor]:
+        descriptors: list[ToolDescriptor] = []
+        for spec in self._specs.values():
+            if not spec.enabled or not spec.supports_scope(scope):
+                continue
+
+            async with self._open_session(spec) as session:
+                tool_result: ListToolsResult = await session.list_tools()
+
+            server_tools = [
+                ToolDescriptor(
+                    server_id=spec.id,
+                    name=tool.name,
+                    description=tool.description or "",
+                    input_schema=tool.inputSchema,
+                    output_schema=tool.outputSchema,
+                )
+                for tool in tool_result.tools
+            ]
+            self._catalog.update(spec.id, server_tools)
+            descriptors.extend(
+                self._catalog.list_for_server(
+                    spec.id,
+                    allowlist=spec.tool_allowlist,
+                )
+            )
+        return descriptors
+
+    async def execute_raw(
+        self,
+        server_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        scope: str | None = None,
+        agent_key: str | None = None,
+    ) -> dict[str, Any]:
+        """Execute an MCP tool and return the normalized payload.
+
+        Performs config/scope/allowlist/cooldown checks and an N-attempt retry
+        on retryable transport errors. Does **not** record budget consumption
+        or run content inspection — those are the responsibility of the
+        ``ToolExecutionService`` hook chain when MCP calls are routed through
+        it.
+
+        ``agent_key`` is accepted for symmetry with :meth:`call_tool` but is
+        not used here; observability metadata travels via the surrounding
+        :class:`ToolInvocation` instead.
+        """
+        del agent_key  # future hooks may consume; current path does not need it
+        spec = self._get_spec(server_id)
+        self._require_access(spec, scope=scope)
+        self._require_tool_allowed(spec, tool_name)
+        result = await self._execute_with_retry(spec, tool_name, arguments)
+        return normalize_result(result, server_id=server_id, tool_name=tool_name)
+
     async def call_tool(
         self,
         server_id: str,
@@ -45,91 +317,64 @@ class MCPRuntime:
         arguments: dict[str, Any],
         *,
         agent_key: str | None = None,
-    ) -> str:
-        """Execute one MCP tool call and return a compact JSON string."""
-        resolved = self._resolved.get(server_id)
-        if resolved is None:
-            raise MCPCallError(
-                f"MCP server {server_id} is not enabled or configured",
-                "config",
-                server_id,
-                tool_name,
-                retryable=False,
-            )
+        scope: str | None = None,
+    ) -> dict[str, Any]:
+        """Convenience entry point that bundles budget, retry, and inspection.
 
-        spec = self._specs[server_id]
+        Prefer routing through :class:`ToolExecutionService` with
+        :meth:`execute_raw` as the runner so audit/argument-policy/content-
+        inspection hooks observe MCP calls under their canonical
+        ``mcp__<server>__<tool>`` tool names.
+        """
+        spec = self._get_spec(server_id)
+        self._require_access(spec, scope=scope)
+        self._require_tool_allowed(spec, tool_name)
+
         if not self._budget.can_call(server_id, spec):
-            return json.dumps(
-                {"error": "budget_exhausted", "server": server_id, "tool": tool_name}
+            raise MCPCallError(
+                message=f"MCP budget exhausted for {server_id}",
+                category=MCPErrorCategory.BUDGET,
+                server_id=server_id,
+                tool_name=tool_name,
             )
 
-        try:
-            async with streamable_http_client(
-                resolved.url, headers=resolved.headers
-            ) as (read, write, _):
-                async with ClientSession(read, write) as session:
-                    await session.initialize()
-                    result: CallToolResult = await session.call_tool(
-                        tool_name, arguments
-                    )
-        except Exception as exc:
-            raise MCPCallError(
-                str(exc), "transport", server_id, tool_name, retryable=True
-            ) from exc
-
-        # Normalize into repo‑owned structure
+        result = await self._execute_with_retry(spec, tool_name, arguments)
         normalized = normalize_result(result, server_id=server_id, tool_name=tool_name)
 
-        # Run content inspection *before* allowing content into prompt context
-        decision = await self._inspect(
+        decision, approved_content = await self._inspect(
             normalized,
-            server_id=server_id,
+            spec=spec,
             tool_name=tool_name,
             agent_key=agent_key,
         )
-        if decision.action == "block":
+
+        if decision.action in ("block", "degrade"):
+            self._budget.record_upstream_consumption(server_id)
             raise MCPCallError(
-                "Content blocked by inspection",
-                "inspection",
-                server_id,
-                tool_name,
-                retryable=False,
+                message="MCP content blocked by inspection",
+                category=MCPErrorCategory.INSPECTION,
+                server_id=server_id,
+                tool_name=tool_name,
+                details={"decision": decision.action},
             )
 
-        # Apply sanitized content if available
-        if (
-            decision.action == "sanitize"
-            and decision.sanitized_content is not None
-        ):
-            return decision.sanitized_content
+        if normalized.get("is_error"):
+            self._budget.record_upstream_consumption(server_id)
+            raise MCPCallError(
+                message="MCP tool returned an error payload",
+                category=MCPErrorCategory.TOOL_ERROR,
+                server_id=server_id,
+                tool_name=tool_name,
+                details=normalized,
+            )
 
-        # Record usage after a successful call
-        self._budget.record_call(server_id)
-        return json.dumps(normalized, default=str)
-
-    # ------------------------------------------------------------------
-    async def _inspect(
-        self,
-        normalized: dict[str, Any],
-        *,
-        server_id: str,
-        tool_name: str,
-        agent_key: str | None = None,
-    ) -> InspectionDecision:
-        text = json.dumps(normalized, default=str)
-        envelope = InspectionEnvelope(
-            content_text=text,
-            raw_content=normalized,
-            source_kind=SourceKind.mcp_tool_output,
-            source_name=server_id,
-            tool_name=tool_name,
-            agent_key=agent_key,
-            metadata={
-                "transport": self._specs.get(server_id, MCPServerSpec(id="", description="", transport="streamable_http")).transport,
-                "trust_tier": self._specs.get(server_id, MCPServerSpec(id="", description="", transport="streamable_http")).trust_tier,
-                "payload_profile": "structured_financial"
-                if isinstance(normalized, dict)
-                else "free_text",
-            },
-        )
-        return await self._inspection_service.inspect(envelope)
+        self._budget.record_upstream_consumption(server_id)
+        if isinstance(approved_content, dict):
+            return approved_content
+        return {
+            "server": server_id,
+            "tool": tool_name,
+            "payload_profile": "free_text",
+            "text_content": str(approved_content),
+            "is_error": False,
+        }

--- a/src/mcp/client.py
+++ b/src/mcp/client.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from contextlib import asynccontextmanager
+from typing import Any, AsyncGenerator
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from mcp.types import CallToolResult
+
+from src.mcp.auth import MCPResolvedServer, resolve_auth
+from src.mcp.budget import BudgetTracker
+from src.mcp.catalog import ToolCatalog
+from src.mcp.config import MCPServerSpec
+from src.mcp.errors import MCPCallError
+from src.mcp.normalize import normalize_result
+from src.tooling.inspection_service import INSPECTION_SERVICE
+from src.tooling.inspector import InspectionDecision, InspectionEnvelope, SourceKind
+
+logger = logging.getLogger(__name__)
+
+
+class MCPRuntime:
+    """Runs MCP tool calls against configured servers, with inspection and budgeting."""
+
+    def __init__(self, servers: list[MCPServerSpec], budget_db_path: str) -> None:
+        self._specs = {s.id: s for s in servers}
+        self._resolved: dict[str, MCPResolvedServer] = {}
+        for s in servers:
+            resolved = resolve_auth(s)
+            if resolved is not None:
+                self._resolved[s.id] = resolved
+
+        self._catalog = ToolCatalog()
+        self._budget = BudgetTracker(budget_db_path)
+        self._inspection_service = INSPECTION_SERVICE
+
+    # ------------------------------------------------------------------
+    async def call_tool(
+        self,
+        server_id: str,
+        tool_name: str,
+        arguments: dict[str, Any],
+        *,
+        agent_key: str | None = None,
+    ) -> str:
+        """Execute one MCP tool call and return a compact JSON string."""
+        resolved = self._resolved.get(server_id)
+        if resolved is None:
+            raise MCPCallError(
+                f"MCP server {server_id} is not enabled or configured",
+                "config",
+                server_id,
+                tool_name,
+                retryable=False,
+            )
+
+        spec = self._specs[server_id]
+        if not self._budget.can_call(server_id, spec):
+            return json.dumps(
+                {"error": "budget_exhausted", "server": server_id, "tool": tool_name}
+            )
+
+        try:
+            async with streamable_http_client(
+                resolved.url, headers=resolved.headers
+            ) as (read, write, _):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result: CallToolResult = await session.call_tool(
+                        tool_name, arguments
+                    )
+        except Exception as exc:
+            raise MCPCallError(
+                str(exc), "transport", server_id, tool_name, retryable=True
+            ) from exc
+
+        # Normalize into repo‑owned structure
+        normalized = normalize_result(result, server_id=server_id, tool_name=tool_name)
+
+        # Run content inspection *before* allowing content into prompt context
+        decision = await self._inspect(
+            normalized,
+            server_id=server_id,
+            tool_name=tool_name,
+            agent_key=agent_key,
+        )
+        if decision.action == "block":
+            raise MCPCallError(
+                "Content blocked by inspection",
+                "inspection",
+                server_id,
+                tool_name,
+                retryable=False,
+            )
+
+        # Apply sanitized content if available
+        if (
+            decision.action == "sanitize"
+            and decision.sanitized_content is not None
+        ):
+            return decision.sanitized_content
+
+        # Record usage after a successful call
+        self._budget.record_call(server_id)
+        return json.dumps(normalized, default=str)
+
+    # ------------------------------------------------------------------
+    async def _inspect(
+        self,
+        normalized: dict[str, Any],
+        *,
+        server_id: str,
+        tool_name: str,
+        agent_key: str | None = None,
+    ) -> InspectionDecision:
+        text = json.dumps(normalized, default=str)
+        envelope = InspectionEnvelope(
+            content_text=text,
+            raw_content=normalized,
+            source_kind=SourceKind.mcp_tool_output,
+            source_name=server_id,
+            tool_name=tool_name,
+            agent_key=agent_key,
+            metadata={
+                "transport": self._specs.get(server_id, MCPServerSpec(id="", description="", transport="streamable_http")).transport,
+                "trust_tier": self._specs.get(server_id, MCPServerSpec(id="", description="", transport="streamable_http")).trust_tier,
+                "payload_profile": "structured_financial"
+                if isinstance(normalized, dict)
+                else "free_text",
+            },
+        )
+        return await self._inspection_service.inspect(envelope)

--- a/src/mcp/config.py
+++ b/src/mcp/config.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+
+@dataclass
+class MCPAuthSpec:
+    type: Literal["none", "query_api_key", "header_bearer", "header_static", "oauth_client"]
+    param: str | None = None
+    env_var: str | None = None
+
+
+@dataclass
+class MCPServerSpec:
+    id: str
+    description: str
+    transport: Literal["streamable_http", "stdio"]
+    base_url: str | None = None
+    auth: MCPAuthSpec | None = None
+    enabled: bool = True
+    scopes: list[str] = field(default_factory=list)
+    tool_allowlist: list[str] = field(default_factory=list)
+    daily_call_limit: int = 0
+    per_run_limit: int = 0
+    trust_tier: str = "unknown"
+
+    @property
+    def is_enabled(self) -> bool:
+        return self.enabled
+
+
+def load_registry(path: Path) -> list[MCPServerSpec]:
+    if not path.exists():
+        return []
+
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+    result: list[MCPServerSpec] = []
+    for raw in data.get("servers", []):
+        auth_raw = raw.get("auth")
+        auth = (
+            MCPAuthSpec(
+                type=auth_raw.get("type", "none"),
+                param=auth_raw.get("param"),
+                env_var=auth_raw.get("env_var"),
+            )
+            if auth_raw
+            else None
+        )
+        spec = MCPServerSpec(
+            id=raw["id"],
+            description=raw.get("description", ""),
+            transport=raw.get("transport", "streamable_http"),
+            base_url=raw.get("base_url"),
+            auth=auth,
+            enabled=raw.get("enabled", True),
+            scopes=raw.get("scopes", []),
+            tool_allowlist=raw.get("tool_allowlist", []),
+            daily_call_limit=raw.get("daily_call_limit", 0),
+            per_run_limit=raw.get("per_run_limit", 0),
+            trust_tier=raw.get("trust_tier", "unknown"),
+        )
+        result.append(spec)
+
+    return result

--- a/src/mcp/config.py
+++ b/src/mcp/config.py
@@ -3,67 +3,123 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
+
+SUPPORTED_TRANSPORTS = frozenset({"streamable_http", "stdio"})
+SUPPORTED_AUTH_TYPES = frozenset(
+    {"none", "query_api_key", "header_bearer", "header_static"}
+)
+SUPPORTED_TRUST_TIERS = frozenset({"official_vendor", "community", "unknown"})
 
 
-@dataclass
+@dataclass(frozen=True)
 class MCPAuthSpec:
-    type: Literal["none", "query_api_key", "header_bearer", "header_static", "oauth_client"]
+    type: Literal["none", "query_api_key", "header_bearer", "header_static"] = "none"
     param: str | None = None
     env_var: str | None = None
 
+    def __post_init__(self) -> None:
+        if self.type not in SUPPORTED_AUTH_TYPES:
+            raise ValueError(f"Unsupported MCP auth type: {self.type!r}")
+        if self.type != "none" and not self.env_var:
+            raise ValueError("MCP auth config must declare env_var for non-none auth")
 
-@dataclass
+
+@dataclass(frozen=True)
 class MCPServerSpec:
     id: str
     description: str
     transport: Literal["streamable_http", "stdio"]
     base_url: str | None = None
+    command: str | None = None
+    args: list[str] = field(default_factory=list)
+    cwd: str | None = None
+    env_vars: list[str] = field(default_factory=list)
     auth: MCPAuthSpec | None = None
     enabled: bool = True
     scopes: list[str] = field(default_factory=list)
     tool_allowlist: list[str] = field(default_factory=list)
     daily_call_limit: int = 0
     per_run_limit: int = 0
-    trust_tier: str = "unknown"
+    trust_tier: Literal["official_vendor", "community", "unknown"] = "unknown"
 
-    @property
-    def is_enabled(self) -> bool:
-        return self.enabled
+    def __post_init__(self) -> None:
+        if not self.id:
+            raise ValueError("MCP server id must not be empty")
+        if self.transport not in SUPPORTED_TRANSPORTS:
+            raise ValueError(f"Unsupported MCP transport: {self.transport!r}")
+        if self.transport == "streamable_http" and not self.base_url:
+            raise ValueError(
+                f"MCP server {self.id!r} uses streamable_http but has no base_url"
+            )
+        if self.transport == "stdio" and not self.command:
+            raise ValueError(
+                f"MCP server {self.id!r} uses stdio but has no command configured"
+            )
+        if self.trust_tier not in SUPPORTED_TRUST_TIERS:
+            raise ValueError(
+                f"MCP server {self.id!r} has unsupported trust_tier {self.trust_tier!r}"
+            )
+        if self.daily_call_limit < 0 or self.per_run_limit < 0:
+            raise ValueError("MCP call limits must be non-negative")
+
+    def supports_scope(self, scope: str | None) -> bool:
+        if scope is None:
+            return True
+        return scope in self.scopes
 
 
-def load_registry(path: Path) -> list[MCPServerSpec]:
+def _load_auth(raw: dict[str, Any] | None) -> MCPAuthSpec | None:
+    if not raw:
+        return None
+    return MCPAuthSpec(
+        type=raw.get("type", "none"),
+        param=raw.get("param"),
+        env_var=raw.get("env_var"),
+    )
+
+
+def load_registry(path: Path, *, required: bool = False) -> list[MCPServerSpec]:
     if not path.exists():
+        if required:
+            raise ValueError(f"MCP registry file not found: {path}")
         return []
 
-    with open(path, "r", encoding="utf-8") as fh:
+    with open(path, encoding="utf-8") as fh:
         data = json.load(fh)
 
+    raw_servers = data.get("servers", [])
+    if not isinstance(raw_servers, list):
+        raise ValueError("MCP registry must contain a top-level 'servers' list")
+
     result: list[MCPServerSpec] = []
-    for raw in data.get("servers", []):
-        auth_raw = raw.get("auth")
-        auth = (
-            MCPAuthSpec(
-                type=auth_raw.get("type", "none"),
-                param=auth_raw.get("param"),
-                env_var=auth_raw.get("env_var"),
+    for raw in raw_servers:
+        if not isinstance(raw, dict):
+            raise ValueError("Each MCP server entry must be a JSON object")
+        result.append(
+            MCPServerSpec(
+                id=raw["id"],
+                description=raw.get("description", ""),
+                transport=raw.get("transport", "streamable_http"),
+                base_url=raw.get("base_url"),
+                command=raw.get("command"),
+                args=list(raw.get("args", [])),
+                cwd=raw.get("cwd"),
+                env_vars=list(raw.get("env_vars", [])),
+                auth=_load_auth(raw.get("auth")),
+                enabled=raw.get("enabled", True),
+                scopes=list(raw.get("scopes", [])),
+                tool_allowlist=list(raw.get("tool_allowlist", [])),
+                daily_call_limit=raw.get("daily_call_limit", 0),
+                per_run_limit=raw.get("per_run_limit", 0),
+                trust_tier=raw.get("trust_tier", "unknown"),
             )
-            if auth_raw
-            else None
         )
-        spec = MCPServerSpec(
-            id=raw["id"],
-            description=raw.get("description", ""),
-            transport=raw.get("transport", "streamable_http"),
-            base_url=raw.get("base_url"),
-            auth=auth,
-            enabled=raw.get("enabled", True),
-            scopes=raw.get("scopes", []),
-            tool_allowlist=raw.get("tool_allowlist", []),
-            daily_call_limit=raw.get("daily_call_limit", 0),
-            per_run_limit=raw.get("per_run_limit", 0),
-            trust_tier=raw.get("trust_tier", "unknown"),
-        )
-        result.append(spec)
+
+    if required and not result:
+        raise ValueError(f"MCP registry is empty: {path}")
+
+    if required and not any(server.enabled for server in result):
+        raise ValueError(f"MCP registry contains no enabled servers: {path}")
 
     return result

--- a/src/mcp/errors.py
+++ b/src/mcp/errors.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+class MCPCallError(Exception):
+    """Error during an MCP tool call."""
+
+    def __init__(
+        self,
+        message: str,
+        category: str,
+        server_id: str,
+        tool_name: str | None = None,
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.category = category
+        self.server_id = server_id
+        self.tool_name = tool_name
+        self.retryable = retryable

--- a/src/mcp/errors.py
+++ b/src/mcp/errors.py
@@ -1,19 +1,193 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
 
-class MCPCallError(Exception):
-    """Error during an MCP tool call."""
+from src.error_safety import redact_sensitive_text
 
-    def __init__(
-        self,
-        message: str,
-        category: str,
-        server_id: str,
-        tool_name: str | None = None,
-        retryable: bool = False,
-    ) -> None:
-        super().__init__(message)
-        self.category = category
-        self.server_id = server_id
-        self.tool_name = tool_name
-        self.retryable = retryable
+
+class MCPErrorCategory(str, Enum):
+    CONFIG = "config"
+    AUTH = "auth"
+    TRANSPORT = "transport"
+    PROTOCOL = "protocol"
+    TOOL_ERROR = "tool_error"
+    INSPECTION = "inspection"
+    BUDGET = "budget"
+
+
+@dataclass(eq=False)
+class MCPCallError(RuntimeError):
+    """Structured MCP runtime error with redacted operator-facing details."""
+
+    message: str
+    category: MCPErrorCategory
+    server_id: str
+    tool_name: str | None = None
+    retryable: bool = False
+    http_status: int | None = None
+    json_rpc_code: int | None = None
+    retry_after_seconds: int | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        RuntimeError.__init__(self, self.message)
+
+
+_NON_RETRYABLE_JSON_RPC_CODES = frozenset({-32700, -32600, -32601, -32602})
+
+
+def _sanitize(text: str, *, max_chars: int = 512) -> str:
+    return redact_sensitive_text(text, max_chars=max_chars)
+
+
+def _parse_retry_after(value: str | None) -> int | None:
+    if not value:
+        return None
+    try:
+        seconds = int(value)
+    except (TypeError, ValueError):
+        return None
+    if seconds < 0:
+        return None
+    return seconds
+
+
+def classify_mcp_error(
+    exc: BaseException,
+    *,
+    server_id: str,
+    tool_name: str | None = None,
+) -> MCPCallError:
+    """Translate a transport/protocol exception into a structured MCPCallError.
+
+    Recognized layers (in order):
+      * ``mcp.shared.exceptions.McpError`` — protocol-level JSON-RPC error
+      * ``httpx.HTTPStatusError`` — HTTP layer (401/403→AUTH, 429/5xx→TRANSPORT, other 4xx→PROTOCOL)
+      * ``httpx`` connection/timeout errors — TRANSPORT, retryable
+      * everything else — TRANSPORT, non-retryable
+
+    The original exception is preserved by the caller via ``raise X from exc``.
+    """
+
+    # Protocol-level: MCP McpError carries a JSON-RPC code.
+    mcp_error_type: type[Any] | None
+    try:
+        from mcp.shared.exceptions import McpError as _McpError
+
+        mcp_error_type = _McpError
+    except ImportError:  # pragma: no cover - mcp dep guaranteed at runtime
+        mcp_error_type = None
+
+    if mcp_error_type is not None and isinstance(exc, mcp_error_type):
+        err_obj = getattr(exc, "error", None)
+        json_rpc_code = getattr(err_obj, "code", None) if err_obj is not None else None
+        message = (
+            getattr(err_obj, "message", None) if err_obj is not None else None
+        ) or "MCP protocol error"
+        retryable = json_rpc_code not in _NON_RETRYABLE_JSON_RPC_CODES
+        return MCPCallError(
+            message=_sanitize(str(message)),
+            category=MCPErrorCategory.PROTOCOL,
+            server_id=server_id,
+            tool_name=tool_name,
+            json_rpc_code=json_rpc_code,
+            retryable=retryable,
+        )
+
+    # HTTP layer: differentiate auth/rate-limit/server-error/other.
+    try:
+        import httpx
+    except ImportError:  # pragma: no cover - httpx is a transitive dep of mcp
+        httpx = None  # type: ignore[assignment]
+
+    if httpx is not None and isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        retry_after = _parse_retry_after(exc.response.headers.get("retry-after"))
+        if status in (401, 403):
+            return MCPCallError(
+                message=_sanitize(f"Upstream HTTP {status}"),
+                category=MCPErrorCategory.AUTH,
+                server_id=server_id,
+                tool_name=tool_name,
+                http_status=status,
+                retryable=False,
+            )
+        if status == 429:
+            return MCPCallError(
+                message=_sanitize("Upstream rate-limited"),
+                category=MCPErrorCategory.TRANSPORT,
+                server_id=server_id,
+                tool_name=tool_name,
+                http_status=status,
+                retry_after_seconds=retry_after,
+                retryable=True,
+            )
+        if 500 <= status < 600:
+            return MCPCallError(
+                message=_sanitize(f"Upstream HTTP {status}"),
+                category=MCPErrorCategory.TRANSPORT,
+                server_id=server_id,
+                tool_name=tool_name,
+                http_status=status,
+                retry_after_seconds=retry_after,
+                retryable=True,
+            )
+        return MCPCallError(
+            message=_sanitize(f"Upstream HTTP {status}"),
+            category=MCPErrorCategory.PROTOCOL,
+            server_id=server_id,
+            tool_name=tool_name,
+            http_status=status,
+            retryable=False,
+        )
+
+    if httpx is not None and isinstance(
+        exc,
+        httpx.ConnectError
+        | httpx.TimeoutException
+        | httpx.ReadError
+        | httpx.WriteError
+        | httpx.RemoteProtocolError,
+    ):
+        return MCPCallError(
+            message=_sanitize(str(exc)),
+            category=MCPErrorCategory.TRANSPORT,
+            server_id=server_id,
+            tool_name=tool_name,
+            retryable=True,
+        )
+
+    # Generic fallback: unknown error layer.
+    return MCPCallError(
+        message=_sanitize(str(exc)),
+        category=MCPErrorCategory.TRANSPORT,
+        server_id=server_id,
+        tool_name=tool_name,
+        retryable=False,
+    )
+
+
+_MCP_TOOL_PREFIX = "mcp__"
+
+
+def parse_mcp_tool_name(name: str) -> tuple[str, str] | None:
+    """Parse a hook-friendly tool name like ``mcp__<server>__<tool>``.
+
+    Returns ``(server_id, tool_name)`` or ``None`` if the name is not an MCP-prefixed
+    tool. ``tool`` may itself contain ``__`` (we only split on the first separator
+    after the prefix).
+    """
+    if not name.startswith(_MCP_TOOL_PREFIX):
+        return None
+    rest = name[len(_MCP_TOOL_PREFIX) :]
+    server_id, sep, tool_name = rest.partition("__")
+    if not sep or not server_id or not tool_name:
+        return None
+    return server_id, tool_name
+
+
+def make_mcp_tool_name(server_id: str, tool_name: str) -> str:
+    """Build the canonical hook-friendly MCP tool name."""
+    return f"{_MCP_TOOL_PREFIX}{server_id}__{tool_name}"

--- a/src/mcp/normalize.py
+++ b/src/mcp/normalize.py
@@ -6,32 +6,75 @@ from typing import Any
 from mcp.types import CallToolResult, TextContent
 
 
+def _looks_structured_financial(value: Any) -> bool:
+    if isinstance(value, dict):
+        lowered = {str(key).lower() for key in value.keys()}
+        financial_markers = {
+            "data",
+            "price",
+            "symbol",
+            "marketcap",
+            "revenue",
+            "netincome",
+            "rsi",
+            "volume",
+        }
+        if lowered & financial_markers:
+            return True
+        return any(_looks_structured_financial(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_looks_structured_financial(item) for item in value[:5])
+    return isinstance(value, int | float)
+
+
+def _parse_json_text(text: str) -> Any | None:
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
 def normalize_result(
     result: CallToolResult,
     server_id: str,
     tool_name: str,
 ) -> dict[str, Any]:
-    """Convert a raw MCP CallToolResult into a dict suitable for inspection."""
+    """Convert a raw MCP CallToolResult into a stable repo-owned shape."""
 
-    text_parts: list[str] = []
-    for item in result.content:
-        if isinstance(item, TextContent):
-            text_parts.append(item.text)
+    text_parts: list[str] = [
+        item.text for item in result.content if isinstance(item, TextContent)
+    ]
+    combined_text = "\n".join(text_parts).strip()
+    parsed_text_json = _parse_json_text(combined_text)
+    structured_content = result.structuredContent
 
-    combined = "\n".join(text_parts)
+    if structured_content is not None:
+        payload_profile = (
+            "structured_financial"
+            if _looks_structured_financial(structured_content)
+            else "structured_json"
+        )
+    elif parsed_text_json is not None:
+        payload_profile = (
+            "structured_financial"
+            if _looks_structured_financial(parsed_text_json)
+            else "structured_json"
+        )
+    else:
+        payload_profile = "free_text"
 
-    try:
-        parsed = json.loads(combined)
-        return {
-            "server": server_id,
-            "tool": tool_name,
-            "result": parsed,
-            "is_error": result.isError,
-        }
-    except (json.JSONDecodeError, TypeError):
-        return {
-            "server": server_id,
-            "tool": tool_name,
-            "text": combined,
-            "is_error": result.isError,
-        }
+    normalized: dict[str, Any] = {
+        "server": server_id,
+        "tool": tool_name,
+        "is_error": result.isError,
+        "payload_profile": payload_profile,
+    }
+    if structured_content is not None:
+        normalized["structured_content"] = structured_content
+    if parsed_text_json is not None:
+        normalized["parsed_text_json"] = parsed_text_json
+    if combined_text:
+        normalized["text_content"] = combined_text
+    return normalized

--- a/src/mcp/normalize.py
+++ b/src/mcp/normalize.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from mcp.types import CallToolResult, TextContent
+
+
+def normalize_result(
+    result: CallToolResult,
+    server_id: str,
+    tool_name: str,
+) -> dict[str, Any]:
+    """Convert a raw MCP CallToolResult into a dict suitable for inspection."""
+
+    text_parts: list[str] = []
+    for item in result.content:
+        if isinstance(item, TextContent):
+            text_parts.append(item.text)
+
+    combined = "\n".join(text_parts)
+
+    try:
+        parsed = json.loads(combined)
+        return {
+            "server": server_id,
+            "tool": tool_name,
+            "result": parsed,
+            "is_error": result.isError,
+        }
+    except (json.JSONDecodeError, TypeError):
+        return {
+            "server": server_id,
+            "tool": tool_name,
+            "text": combined,
+            "is_error": result.isError,
+        }

--- a/src/mcp/session_cache.py
+++ b/src/mcp/session_cache.py
@@ -1,0 +1,5 @@
+"""MCP session cache placeholder."""
+
+
+class SessionCache:
+    pass

--- a/src/mcp/session_cache.py
+++ b/src/mcp/session_cache.py
@@ -1,5 +1,0 @@
-"""MCP session cache placeholder."""
-
-
-class SessionCache:
-    pass

--- a/src/runtime_services.py
+++ b/src/runtime_services.py
@@ -20,6 +20,7 @@ from src.tooling.runtime import TOOL_SERVICE, ToolExecutionService, ToolHook
 
 if TYPE_CHECKING:
     from src.data.fetcher import SmartMarketDataFetcher
+    from src.mcp.client import MCPRuntime
 
 
 @dataclass(frozen=True)
@@ -37,6 +38,7 @@ class RuntimeServices:
     tool_service: ToolExecutionService
     inspection_service: InspectionService
     providers: ProviderRuntime | None = None
+    mcp_runtime: MCPRuntime | None = None
 
     def with_tool_service(self, tool_service: ToolExecutionService) -> RuntimeServices:
         return replace(self, tool_service=tool_service)
@@ -203,8 +205,32 @@ def build_runtime_services_from_config(
             fail_policy=fail_policy,
             backend=backend_name,
         )
+    # Build MCP runtime if enabled
+    mcp_runtime = None
+    if getattr(config, "mcp_enabled", False):
+        try:
+            from src.mcp.config import load_registry
+            from src.mcp.client import MCPRuntime
+
+            servers_path = config.mcp_servers_path
+            servers = load_registry(servers_path)
+            mcp_runtime = MCPRuntime(
+                servers=servers,
+                budget_db_path=str(config.mcp_usage_db_path),
+            )
+            if logger is not None:
+                logger.info(
+                    "mcp_runtime_initialized",
+                    server_count=len([s for s in servers if s.enabled]),
+                )
+        except Exception as exc:
+            if logger is not None:
+                logger.warning("mcp_runtime_init_failed", error=str(exc))
+            mcp_runtime = None
+
     return RuntimeServices(
         tool_service=ToolExecutionService(hooks),
         inspection_service=inspection_service,
         providers=provider_runtime or build_provider_runtime(),
+        mcp_runtime=mcp_runtime,
     )

--- a/src/runtime_services.py
+++ b/src/runtime_services.py
@@ -11,11 +11,13 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from langchain_core.rate_limiters import BaseRateLimiter
 
+from src.error_safety import redact_sensitive_text
 from src.tooling.inspection_service import INSPECTION_SERVICE, InspectionService
+from src.tooling.inspector import ContentInspector
 from src.tooling.runtime import TOOL_SERVICE, ToolExecutionService, ToolHook
 
 if TYPE_CHECKING:
@@ -145,7 +147,8 @@ def build_runtime_services_from_config(
     from src.tooling.tool_argument_policy import ToolArgumentPolicyHook
 
     inspection_service = InspectionService()
-    hooks = []
+    hooks: list[ToolHook] = []
+    providers = provider_runtime or build_provider_runtime()
 
     if enable_tool_audit:
         hooks.append(LoggingToolAuditHook())
@@ -156,68 +159,71 @@ def build_runtime_services_from_config(
             mode="warn",
             fail_policy="fail_open",
         )
-        return RuntimeServices(
-            tool_service=ToolExecutionService(hooks),
-            inspection_service=inspection_service,
-            providers=provider_runtime or build_provider_runtime(),
-        )
-
-    mode = config.untrusted_content_inspection_mode
-    fail_policy = config.untrusted_content_fail_policy
-    backend_name = config.untrusted_content_backend
-
-    if backend_name == "null" or not backend_name:
-        inspector = NullInspector()
-    elif backend_name == "python":
-        from src.tooling.heuristic_inspector import HeuristicInspector
-
-        inspector = HeuristicInspector()
-    elif backend_name == "composite":
-        from src.tooling.escalating_inspector import EscalatingInspector
-        from src.tooling.heuristic_inspector import HeuristicInspector
-        from src.tooling.llm_judge_inspector import LLMJudgeInspector
-
-        inspector = EscalatingInspector(
-            heuristic=HeuristicInspector(),
-            judge=LLMJudgeInspector(),
-        )
     else:
-        raise ValueError(
-            f"UNTRUSTED_CONTENT_BACKEND={backend_name!r} is not implemented. "
-            "Supported: null, python, composite."
-        )
+        mode = config.untrusted_content_inspection_mode
+        fail_policy = config.untrusted_content_fail_policy
+        backend_name = config.untrusted_content_backend
 
-    inspection_service.configure(inspector, mode=mode, fail_policy=fail_policy)
-    if logger is not None:
-        logger.info(
-            "content_inspection_configured",
-            inspector=type(inspector).__name__,
-            mode=mode,
-            fail_policy=fail_policy,
+        inspector: ContentInspector
+        if backend_name == "null" or not backend_name:
+            inspector = NullInspector()
+        elif backend_name == "python":
+            from src.tooling.heuristic_inspector import HeuristicInspector
+
+            inspector = HeuristicInspector()
+        elif backend_name == "composite":
+            from src.tooling.escalating_inspector import EscalatingInspector
+            from src.tooling.heuristic_inspector import HeuristicInspector
+            from src.tooling.llm_judge_inspector import LLMJudgeInspector
+
+            inspector = EscalatingInspector(
+                heuristic=HeuristicInspector(),
+                judge=LLMJudgeInspector(),
+            )
+        else:
+            raise ValueError(
+                f"UNTRUSTED_CONTENT_BACKEND={backend_name!r} is not implemented. "
+                "Supported: null, python, composite."
+            )
+
+        inspection_service.configure(inspector, mode=mode, fail_policy=fail_policy)
+        if logger is not None:
+            logger.info(
+                "content_inspection_configured",
+                inspector=type(inspector).__name__,
+                mode=mode,
+                fail_policy=fail_policy,
+            )
+        arg_policy_mode: Literal["warn", "block"] = (
+            "block" if mode == "block" else "warn"
         )
-    arg_policy_mode = "block" if mode == "block" else "warn"
-    hooks.append(ToolArgumentPolicyHook(mode=arg_policy_mode))
-    hooks.append(ContentInspectionHook(inspection_service))
-    if logger is not None:
-        logger.info(
-            "content_inspection_enabled",
-            mode=mode,
-            fail_policy=fail_policy,
-            backend=backend_name,
-        )
+        hooks.append(ToolArgumentPolicyHook(mode=arg_policy_mode))
+        hooks.append(ContentInspectionHook(inspection_service))
+        if logger is not None:
+            logger.info(
+                "content_inspection_enabled",
+                mode=mode,
+                fail_policy=fail_policy,
+                backend=backend_name,
+            )
+
     # Build MCP runtime if enabled
     mcp_runtime = None
     if getattr(config, "mcp_enabled", False):
         try:
-            from src.mcp.config import load_registry
+            from src.mcp.budget import MCPBudgetHook
             from src.mcp.client import MCPRuntime
+            from src.mcp.config import load_registry
 
             servers_path = config.mcp_servers_path
-            servers = load_registry(servers_path)
+            # MCP is optional: invalid registry config disables MCP for this run
+            # with a warning instead of breaking the rest of the analysis.
+            servers = load_registry(servers_path, required=True)
             mcp_runtime = MCPRuntime(
                 servers=servers,
                 budget_db_path=str(config.mcp_usage_db_path),
             )
+            hooks.append(MCPBudgetHook(mcp_runtime))
             if logger is not None:
                 logger.info(
                     "mcp_runtime_initialized",
@@ -225,12 +231,15 @@ def build_runtime_services_from_config(
                 )
         except Exception as exc:
             if logger is not None:
-                logger.warning("mcp_runtime_init_failed", error=str(exc))
+                logger.warning(
+                    "mcp_runtime_init_failed",
+                    error=redact_sensitive_text(str(exc), max_chars=120),
+                )
             mcp_runtime = None
 
     return RuntimeServices(
         tool_service=ToolExecutionService(hooks),
         inspection_service=inspection_service,
-        providers=provider_runtime or build_provider_runtime(),
+        providers=providers,
         mcp_runtime=mcp_runtime,
     )

--- a/src/tavily_utils.py
+++ b/src/tavily_utils.py
@@ -102,8 +102,14 @@ async def tavily_search_with_timeout(
     """
     if not _tavily_tool:
         return None
+    from src.async_utils import run_with_hard_timeout
+
     try:
-        raw = await asyncio.wait_for(_tavily_tool.ainvoke(query), timeout=timeout)
+        raw = await run_with_hard_timeout(
+            _tavily_tool.ainvoke(query),
+            timeout=timeout,
+            label=f"tavily:{query.get('query', '')[:60]}",
+        )
     except asyncio.TimeoutError:
         logger.warning(
             "tavily_search_timeout",
@@ -136,8 +142,14 @@ async def search_tavily_inspected(
     if tool is None:
         return None
 
+    from src.async_utils import run_with_hard_timeout
+
     try:
-        raw = await asyncio.wait_for(tool.ainvoke({"query": query}), timeout=timeout)
+        raw = await run_with_hard_timeout(
+            tool.ainvoke({"query": query}),
+            timeout=timeout,
+            label=f"tavily:{profile}:{query[:60]}",
+        )
     except asyncio.TimeoutError:
         logger.warning(
             "tavily_search_timeout",

--- a/src/tooling/heuristic_inspector.py
+++ b/src/tooling/heuristic_inspector.py
@@ -365,6 +365,13 @@ class HeuristicInspector:
         if cc_hit:
             total_weight += 2.0
 
+        # Adjust weight for structured MCP output
+        if envelope.source_kind == SourceKind.mcp_tool_output:
+            payload_profile = (envelope.metadata or {}).get("payload_profile", "free_text")
+            trust_tier = (envelope.metadata or {}).get("trust_tier", "unknown")
+            if payload_profile == "structured_financial" and trust_tier == "official_vendor":
+                total_weight *= 0.5
+
         threat_types: list[str] = sorted(
             {h.signal.threat_type for h in hits}
             | ({"control_chars"} if cc_hit else set())

--- a/src/tooling/inspection_hook.py
+++ b/src/tooling/inspection_hook.py
@@ -18,7 +18,11 @@ from typing import Any
 
 import structlog
 
-from src.runtime_services import get_current_inspection_service
+from src.mcp.errors import parse_mcp_tool_name
+from src.runtime_services import (
+    get_current_inspection_service,
+    get_current_runtime_services,
+)
 from src.tooling.inspection_service import InspectionService
 from src.tooling.inspector import InspectionEnvelope, SourceKind
 from src.tooling.runtime import ToolInvocation, ToolResult
@@ -69,6 +73,39 @@ def _serialize_for_inspection(
     }
 
 
+def _build_mcp_metadata(
+    *,
+    server_id: str,
+    tool_name: str,
+    result_value: Any,
+    serialization_meta: dict[str, Any],
+    call: ToolInvocation,
+) -> dict[str, Any]:
+    metadata = {
+        **serialization_meta,
+        "source": call.source,
+        "args_keys": list(call.args.keys()) if call.args else [],
+        "mcp_server_id": server_id,
+        "mcp_tool_name": tool_name,
+        "payload_profile": "free_text",
+        "trust_tier": "unknown",
+    }
+
+    if isinstance(result_value, dict):
+        payload_profile = result_value.get("payload_profile")
+        if isinstance(payload_profile, str) and payload_profile:
+            metadata["payload_profile"] = payload_profile
+
+    services = get_current_runtime_services()
+    runtime = services.mcp_runtime if services is not None else None
+    spec = runtime.specs.get(server_id) if runtime is not None else None
+    if spec is not None:
+        metadata["trust_tier"] = spec.trust_tier
+        metadata["transport"] = spec.transport
+
+    return metadata
+
+
 class ContentInspectionHook:
     """Inspect tool outputs through an InspectionService.
 
@@ -100,18 +137,37 @@ class ContentInspectionHook:
             )
             return result
 
-        envelope = InspectionEnvelope(
-            content_text=content_text,
-            raw_content=result.value,
-            source_kind=SourceKind.tool_output,
-            source_name=call.name,
-            tool_name=call.name,
-            agent_key=call.agent_key,
-            metadata={
+        mcp_parts = parse_mcp_tool_name(call.name)
+        if mcp_parts is not None:
+            mcp_server_id, mcp_inner_tool = mcp_parts
+            source_kind = SourceKind.mcp_tool_output
+            source_name = mcp_server_id
+            tool_name_for_envelope = mcp_inner_tool
+            metadata = _build_mcp_metadata(
+                server_id=mcp_server_id,
+                tool_name=mcp_inner_tool,
+                result_value=result.value,
+                serialization_meta=serialization_meta,
+                call=call,
+            )
+        else:
+            source_kind = SourceKind.tool_output
+            source_name = call.name
+            tool_name_for_envelope = call.name
+            metadata = {
                 "source": call.source,
                 "args_keys": list(call.args.keys()) if call.args else [],
                 **serialization_meta,
-            },
+            }
+
+        envelope = InspectionEnvelope(
+            content_text=content_text,
+            raw_content=result.value,
+            source_kind=source_kind,
+            source_name=source_name,
+            tool_name=tool_name_for_envelope,
+            agent_key=call.agent_key,
+            metadata=metadata,
         )
 
         service = self._inspection_service or get_current_inspection_service()

--- a/src/tooling/inspection_service.py
+++ b/src/tooling/inspection_service.py
@@ -73,11 +73,14 @@ class InspectionService:
     def mode(self) -> str:
         return self._mode
 
-    async def check(self, envelope: InspectionEnvelope) -> Any:
-        """Inspect *envelope* and return the approved content string.
+    async def evaluate(
+        self,
+        envelope: InspectionEnvelope,
+    ) -> tuple[InspectionDecision, Any]:
+        """Inspect *envelope* and return both decision and approved content.
 
-        Returns the original value, a sanitized replacement string, or a
-        blocked-placeholder string depending on the decision and configured mode.
+        This is the richer variant used by callsites that need the underlying
+        inspection decision for control-flow, not just the approved content.
         """
         original_value = (
             envelope.raw_content
@@ -96,7 +99,16 @@ class InspectionService:
                     error=str(exc),
                     fail_policy=self._fail_policy,
                 )
-                return _BLOCKED_PLACEHOLDER.format(reason=reason)
+                blocked = _BLOCKED_PLACEHOLDER.format(reason=reason)
+                return (
+                    InspectionDecision(
+                        action="block",
+                        threat_level="high",
+                        findings=["inspection backend error"],
+                        reason=reason,
+                    ),
+                    blocked,
+                )
             logger.warning(
                 "content_inspection_backend_error",
                 source_kind=envelope.source_kind.value,
@@ -104,10 +116,13 @@ class InspectionService:
                 error=str(exc),
                 fail_policy=self._fail_policy,
             )
-            return original_value
+            return (
+                InspectionDecision(action="allow", threat_level="safe"),
+                original_value,
+            )
 
         if decision.action == "allow" and decision.threat_level == "safe":
-            return original_value
+            return decision, original_value
 
         # Log findings for non-trivial decisions regardless of mode.
         if decision.findings or decision.threat_types:
@@ -128,19 +143,26 @@ class InspectionService:
         if decision.action in ("block", "degrade"):
             if self._mode == "block":
                 reason = decision.reason or "; ".join(decision.findings) or "policy"
-                return _BLOCKED_PLACEHOLDER.format(reason=reason)
+                return decision, _BLOCKED_PLACEHOLDER.format(reason=reason)
             if self._mode == "sanitize" and decision.sanitized_content is not None:
-                return decision.sanitized_content
-            # warn (or sanitize-without-replacement): log and pass through
-            return original_value
+                return decision, decision.sanitized_content
+            return decision, original_value
 
         if decision.action == "sanitize":
             if self._mode in ("sanitize", "block") and decision.sanitized_content:
-                return decision.sanitized_content
-            return original_value
+                return decision, decision.sanitized_content
+            return decision, original_value
 
-        # action == "allow" with non-safe threat level → warn and pass through
-        return original_value
+        return decision, original_value
+
+    async def check(self, envelope: InspectionEnvelope) -> Any:
+        """Inspect *envelope* and return the approved content string.
+
+        Returns the original value, a sanitized replacement string, or a
+        blocked-placeholder string depending on the decision and configured mode.
+        """
+        _, approved = await self.evaluate(envelope)
+        return approved
 
 
 # ---------------------------------------------------------------------------

--- a/src/tooling/runtime.py
+++ b/src/tooling/runtime.py
@@ -13,6 +13,7 @@ from typing import Any, Literal, Protocol, TypeAlias
 
 import structlog
 
+from src.async_utils import run_with_hard_timeout
 from src.error_safety import redact_sensitive_text
 from src.observability import start_tool_observation
 from src.runtime_diagnostics import classify_failure
@@ -123,8 +124,10 @@ class ToolExecutionService:
                 },
             ):
                 result = ToolResult(
-                    value=await asyncio.wait_for(
-                        runner(call.args), timeout=TOOL_CALL_TIMEOUT_SECONDS
+                    value=await run_with_hard_timeout(
+                        runner(call.args),
+                        timeout=TOOL_CALL_TIMEOUT_SECONDS,
+                        label=f"tool:{call.name}",
                     )
                 )
         except asyncio.TimeoutError as exc:
@@ -143,6 +146,14 @@ class ToolExecutionService:
             # Failed executions propagate immediately so callers keep the original
             # stack and error semantics.
             details = classify_failure(exc, provider="unknown")
+            is_mcp_error = False
+            try:  # Avoid import-time coupling for the non-MCP path.
+                from src.mcp.errors import MCPCallError
+
+                is_mcp_error = isinstance(exc, MCPCallError)
+            except Exception:  # pragma: no cover - defensive import fallback
+                is_mcp_error = False
+
             logger.error(
                 "tool_call_runner_failed",
                 tool=call.name,
@@ -154,7 +165,7 @@ class ToolExecutionService:
                 error_type=details.error_type,
                 root_cause_type=details.root_cause_type,
                 error_message=details.message,
-                exc_info=True,
+                exc_info=not is_mcp_error,
             )
             raise
 

--- a/src/tools/shared.py
+++ b/src/tools/shared.py
@@ -108,8 +108,14 @@ def _format_and_truncate_tavily_result(
 
 
 async def fetch_with_timeout(coroutine, timeout_seconds=10, error_msg="Timeout"):
+    from src.async_utils import run_with_hard_timeout
+
     try:
-        return await asyncio.wait_for(coroutine, timeout=timeout_seconds)
+        return await run_with_hard_timeout(
+            coroutine,
+            timeout=timeout_seconds,
+            label=f"shared.fetch_with_timeout:{error_msg}",
+        )
     except asyncio.TimeoutError:
         logger.warning(f"YFINANCE TIMEOUT: {error_msg}")
         return None
@@ -200,15 +206,18 @@ def _sanitize_for_json(data: dict) -> dict:
 
 async def _ddg_search(query: str, max_results: int = 5) -> list[dict]:
     """DuckDuckGo fallback search. Returns list of {title, href, body}."""
+    from src.async_utils import run_with_hard_timeout
+
     try:
         from ddgs import DDGS
 
         def _sync_search():
             return DDGS(timeout=5).text(query, max_results=max_results)
 
-        results = await asyncio.wait_for(
+        results = await run_with_hard_timeout(
             asyncio.to_thread(_sync_search),
             timeout=DDG_SEARCH_TIMEOUT_SECONDS,
+            label=f"ddg:{query[:60]}",
         )
         return results if results else []
     except ImportError:

--- a/tests/agents/test_consultant_tools.py
+++ b/tests/agents/test_consultant_tools.py
@@ -13,10 +13,15 @@ import pytest
 
 from src.consultant_tools import (
     FMP_FIELD_MAP,
+    get_consultant_tools,
     spot_check_metric,
     spot_check_metric_alt,
+    spot_check_metric_mcp_fmp,
 )
 from src.data.fmp_fetcher import FMPSubscriptionUnavailableError
+from src.runtime_services import RuntimeServices, use_runtime_services
+from src.tooling.inspection_service import InspectionService
+from src.tooling.runtime import ToolExecutionService, ToolResult
 
 
 class TestSpotCheckMetric:
@@ -271,3 +276,180 @@ class TestSpotCheckMetricAlt:
             endpoint, field = mapping
             assert isinstance(endpoint, str), f"{metric} endpoint should be str"
             assert isinstance(field, str), f"{metric} field should be str"
+
+
+class TestMCPConsultantTools:
+    @pytest.mark.asyncio
+    async def test_fmp_mcp_wrapper_returns_value_from_nested_payload(self):
+        mock_runtime = MagicMock()
+        mock_runtime.execute_raw = AsyncMock(
+            return_value={
+                "structured_content": {"data": [{"priceEarningsRatio": 14.2}]},
+                "payload_profile": "structured_financial",
+            }
+        )
+        services = RuntimeServices(
+            tool_service=ToolExecutionService(),
+            inspection_service=InspectionService(),
+            mcp_runtime=mock_runtime,
+        )
+
+        with use_runtime_services(services):
+            result = json.loads(
+                await spot_check_metric_mcp_fmp.ainvoke(
+                    {"ticker": "7203.T", "metric": "trailingPE"}
+                )
+            )
+
+        assert result["value"] == 14.2
+        assert result["provider"] == "fmp"
+        assert result["source"] == "fmp_mcp"
+        assert result["mcp_tool"] == "statements"
+        assert result["mcp_endpoint"] == "metrics-ratios-ttm"
+        # MCP call must flow through the canonical mcp__server__tool name with
+        # the dispatcher endpoint argument bundled into the args dict.
+        mock_runtime.execute_raw.assert_called_once_with(
+            "fmp_remote",
+            "statements",
+            {"symbol": "7203.T", "endpoint": "metrics-ratios-ttm"},
+            scope="consultant",
+            agent_key="consultant",
+        )
+
+    @pytest.mark.asyncio
+    async def test_fmp_mcp_wrapper_surfaces_vendor_tool_error(self):
+        """When the vendor returns is_error=true (e.g. unknown endpoint), the
+        wrapper must surface the text_content as a structured tool_error rather
+        than fall through to opaque 'unexpected_mcp_payload_shape'."""
+        mock_runtime = MagicMock()
+        mock_runtime.execute_raw = AsyncMock(
+            return_value={
+                "server": "fmp_remote",
+                "tool": "statements",
+                "is_error": True,
+                "payload_profile": "free_text",
+                "text_content": "MCP error -32602: endpoint not allowed on free tier",
+            }
+        )
+        services = RuntimeServices(
+            tool_service=ToolExecutionService(),
+            inspection_service=InspectionService(),
+            mcp_runtime=mock_runtime,
+        )
+
+        with use_runtime_services(services):
+            result = json.loads(
+                await spot_check_metric_mcp_fmp.ainvoke(
+                    {"ticker": "7203.T", "metric": "trailingPE"}
+                )
+            )
+
+        assert result["failure_kind"] == "tool_error"
+        assert "free tier" in result["error"]
+        assert result["source"] == "fmp_mcp"
+
+    @pytest.mark.asyncio
+    async def test_fmp_mcp_wrapper_degrades_when_runtime_missing(self):
+        with patch(
+            "src.consultant_tools.get_current_runtime_services", return_value=None
+        ):
+            result = json.loads(
+                await spot_check_metric_mcp_fmp.ainvoke(
+                    {"ticker": "7203.T", "metric": "trailingPE"}
+                )
+            )
+
+        assert result["failure_kind"] == "config_error"
+        assert result["source"] == "fmp_mcp"
+
+    @pytest.mark.asyncio
+    async def test_fmp_mcp_wrapper_labels_budget_block_correctly(self):
+        with patch(
+            "src.consultant_tools._execute_mcp_via_tool_service",
+            AsyncMock(
+                return_value=ToolResult(
+                    value="TOOL_BLOCKED: MCP budget exhausted for fmp_remote",
+                    blocked=True,
+                    findings=["MCP budget exhausted for fmp_remote"],
+                )
+            ),
+        ):
+            services = RuntimeServices(
+                tool_service=ToolExecutionService(),
+                inspection_service=InspectionService(),
+                mcp_runtime=MagicMock(),
+            )
+            with use_runtime_services(services):
+                result = json.loads(
+                    await spot_check_metric_mcp_fmp.ainvoke(
+                        {"ticker": "7203.T", "metric": "trailingPE"}
+                    )
+                )
+
+        assert result["failure_kind"] == "budget"
+        assert "budget exhausted" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_fmp_mcp_wrapper_preserves_sanitized_text_payload(self):
+        with patch(
+            "src.consultant_tools._execute_mcp_via_tool_service",
+            AsyncMock(
+                return_value=ToolResult(value="sanitized payload", blocked=False)
+            ),
+        ):
+            services = RuntimeServices(
+                tool_service=ToolExecutionService(),
+                inspection_service=InspectionService(),
+                mcp_runtime=MagicMock(),
+            )
+            with use_runtime_services(services):
+                result = json.loads(
+                    await spot_check_metric_mcp_fmp.ainvoke(
+                        {"ticker": "7203.T", "metric": "trailingPE"}
+                    )
+                )
+
+        assert result["text_payload"] == "sanitized payload"
+        assert result["note"] == "mcp_payload_sanitized_or_textual"
+
+    def test_get_consultant_tools_hides_mcp_tools_when_disabled(self):
+        mock_services = MagicMock(mcp_runtime=object())
+        with patch(
+            "src.consultant_tools.get_current_runtime_services",
+            return_value=mock_services,
+        ):
+            with patch("src.consultant_tools.config.consultant_mcp_enabled", False):
+                tools = get_consultant_tools()
+
+        tool_names = {tool.name for tool in tools}
+        assert "spot_check_metric_mcp_fmp" not in tool_names
+
+    def test_get_consultant_tools_hides_mcp_tools_when_servers_are_unavailable(self):
+        mock_runtime = MagicMock()
+        mock_runtime.is_tool_available.return_value = False
+        mock_services = MagicMock(mcp_runtime=mock_runtime)
+
+        with patch(
+            "src.consultant_tools.get_current_runtime_services",
+            return_value=mock_services,
+        ):
+            with patch("src.consultant_tools.config.consultant_mcp_enabled", True):
+                tools = get_consultant_tools()
+
+        tool_names = {tool.name for tool in tools}
+        assert "spot_check_metric_mcp_fmp" not in tool_names
+
+    def test_get_consultant_tools_hides_mcp_tools_without_runtime_capability_check(
+        self,
+    ):
+        mock_services = MagicMock(mcp_runtime=object())
+
+        with patch(
+            "src.consultant_tools.get_current_runtime_services",
+            return_value=mock_services,
+        ):
+            with patch("src.consultant_tools.config.consultant_mcp_enabled", True):
+                tools = get_consultant_tools()
+
+        tool_names = {tool.name for tool in tools}
+        assert "spot_check_metric_mcp_fmp" not in tool_names

--- a/tests/mcp/test_auth.py
+++ b/tests/mcp/test_auth.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+
+from src.mcp.auth import resolve_auth
+from src.mcp.config import MCPAuthSpec, MCPServerSpec
+
+
+@pytest.fixture(autouse=True)
+def _clear_env_file_cache(monkeypatch: pytest.MonkeyPatch):
+    """Each test starts with an empty .env-fallback so it can choose its own."""
+    import src.config as config_module
+
+    config_module._cached_env_file_values.cache_clear()
+    monkeypatch.setattr(config_module, "_cached_env_file_values", lambda: {})
+    yield
+    config_module._cached_env_file_values.cache_clear() if hasattr(
+        config_module._cached_env_file_values, "cache_clear"
+    ) else None
+
+
+def test_resolve_auth_uses_query_key(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("FMP_API_KEY", "secret-token-123")
+    spec = MCPServerSpec(
+        id="fmp_remote",
+        description="FMP",
+        transport="streamable_http",
+        base_url="https://example.test/mcp",
+        auth=MCPAuthSpec(type="query_api_key", param="apikey", env_var="FMP_API_KEY"),
+    )
+
+    resolved = resolve_auth(spec)
+
+    assert resolved is not None
+    assert "apikey=secret-token-123" in (resolved.url or "")
+
+
+def test_resolve_auth_requires_env_var(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("FMP_API_KEY", raising=False)
+    spec = MCPServerSpec(
+        id="fmp_remote",
+        description="FMP",
+        transport="streamable_http",
+        base_url="https://example.test/mcp",
+        auth=MCPAuthSpec(type="query_api_key", param="apikey", env_var="FMP_API_KEY"),
+    )
+
+    with pytest.raises(ValueError, match="Required env var"):
+        resolve_auth(spec)
+
+
+def test_resolve_auth_injects_auth_env_into_stdio_process(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("TWELVE_DATA_API_KEY", "secret-token-123")
+    spec = MCPServerSpec(
+        id="twelvedata_local",
+        description="Twelve Data local MCP",
+        transport="stdio",
+        command="uvx",
+        args=["mcp-server"],
+        auth=MCPAuthSpec(type="header_static", env_var="TWELVE_DATA_API_KEY"),
+    )
+
+    resolved = resolve_auth(spec)
+
+    assert resolved is not None
+    assert resolved.stdio_env["TWELVE_DATA_API_KEY"] == "secret-token-123"
+
+
+def test_resolve_auth_falls_back_to_env_file_when_shell_var_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """`.env` keys must work even if the shell hasn't exported them.
+
+    The repo loads `.env` via pydantic Settings; raw os.getenv does not see
+    those values. resolve_auth uses get_env_value() which falls back to the
+    parsed .env file. This is the regression for the "MCP fails despite
+    FMP_API_KEY being in .env" bug.
+    """
+    import src.config as config_module
+
+    monkeypatch.delenv("FMP_API_KEY", raising=False)
+    monkeypatch.setattr(
+        config_module,
+        "_cached_env_file_values",
+        lambda: {"FMP_API_KEY": "from-dotenv-789"},
+    )
+
+    spec = MCPServerSpec(
+        id="fmp_remote",
+        description="FMP",
+        transport="streamable_http",
+        base_url="https://example.test/mcp",
+        auth=MCPAuthSpec(type="query_api_key", param="apikey", env_var="FMP_API_KEY"),
+    )
+
+    resolved = resolve_auth(spec)
+
+    assert resolved is not None
+    assert "apikey=from-dotenv-789" in (resolved.url or "")
+
+
+def test_resolve_auth_shell_takes_precedence_over_env_file(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Shell-exported var wins over .env so ops/CI overrides remain effective."""
+    import src.config as config_module
+
+    monkeypatch.setenv("FMP_API_KEY", "shell-wins-456")
+    monkeypatch.setattr(
+        config_module,
+        "_cached_env_file_values",
+        lambda: {"FMP_API_KEY": "dotenv-loses-123"},
+    )
+
+    spec = MCPServerSpec(
+        id="fmp_remote",
+        description="FMP",
+        transport="streamable_http",
+        base_url="https://example.test/mcp",
+        auth=MCPAuthSpec(type="query_api_key", param="apikey", env_var="FMP_API_KEY"),
+    )
+
+    resolved = resolve_auth(spec)
+
+    assert resolved is not None
+    assert "apikey=shell-wins-456" in (resolved.url or "")

--- a/tests/mcp/test_budget.py
+++ b/tests/mcp/test_budget.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.mcp.budget import BudgetTracker
+from src.mcp.config import MCPServerSpec
+
+
+def test_budget_tracker_enforces_per_run_and_daily_limits(tmp_path: Path):
+    tracker = BudgetTracker(str(tmp_path / "mcp_usage.db"))
+    spec = MCPServerSpec(
+        id="fmp_remote",
+        description="FMP",
+        transport="streamable_http",
+        base_url="https://example.test/mcp",
+        daily_call_limit=2,
+        per_run_limit=1,
+    )
+
+    assert tracker.can_call("fmp_remote", spec) is True
+    tracker.record_upstream_consumption("fmp_remote")
+    assert tracker.can_call("fmp_remote", spec) is False
+
+
+def test_budget_tracker_persists_daily_counts(tmp_path: Path):
+    db_path = tmp_path / "mcp_usage.db"
+    tracker = BudgetTracker(str(db_path))
+    spec = MCPServerSpec(
+        id="fmp_remote",
+        description="FMP",
+        transport="streamable_http",
+        base_url="https://example.test/mcp",
+        daily_call_limit=1,
+    )
+    tracker.record_upstream_consumption("fmp_remote")
+
+    fresh_tracker = BudgetTracker(str(db_path))
+    assert fresh_tracker.can_call("fmp_remote", spec) is False

--- a/tests/mcp/test_config.py
+++ b/tests/mcp/test_config.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.mcp.config import MCPServerSpec, load_registry
+
+
+def test_load_registry_reads_valid_server(tmp_path: Path):
+    path = tmp_path / "mcp_servers.json"
+    path.write_text(
+        json.dumps(
+            {
+                "servers": [
+                    {
+                        "id": "fmp_remote",
+                        "description": "FMP",
+                        "transport": "streamable_http",
+                        "base_url": "https://example.test/mcp",
+                        "auth": {
+                            "type": "query_api_key",
+                            "param": "apikey",
+                            "env_var": "FMP_API_KEY",
+                        },
+                        "enabled": True,
+                        "scopes": ["consultant"],
+                        "tool_allowlist": ["quote"],
+                        "trust_tier": "official_vendor",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    servers = load_registry(path)
+
+    assert len(servers) == 1
+    assert servers[0].id == "fmp_remote"
+    assert servers[0].supports_scope("consultant") is True
+
+
+def test_load_registry_rejects_unsupported_transport(tmp_path: Path):
+    path = tmp_path / "mcp_servers.json"
+    path.write_text(
+        json.dumps(
+            {
+                "servers": [
+                    {
+                        "id": "bad",
+                        "description": "bad",
+                        "transport": "sse",
+                        "base_url": "https://example.test/mcp",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Unsupported MCP transport"):
+        load_registry(path)
+
+
+def test_load_registry_required_missing_file_fails_fast(tmp_path: Path):
+    path = tmp_path / "missing_mcp_servers.json"
+
+    with pytest.raises(ValueError, match="MCP registry file not found"):
+        load_registry(path, required=True)
+
+
+def test_load_registry_required_rejects_no_enabled_servers(tmp_path: Path):
+    path = tmp_path / "mcp_servers.json"
+    path.write_text(
+        json.dumps(
+            {
+                "servers": [
+                    {
+                        "id": "fmp_remote",
+                        "description": "FMP",
+                        "transport": "streamable_http",
+                        "base_url": "https://example.test/mcp",
+                        "enabled": False,
+                        "scopes": ["consultant"],
+                        "tool_allowlist": ["quote"],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="contains no enabled servers"):
+        load_registry(path, required=True)
+
+
+def test_server_spec_rejects_unknown_trust_tier():
+    with pytest.raises(ValueError, match="unsupported trust_tier"):
+        MCPServerSpec(
+            id="bad",
+            description="bad",
+            transport="streamable_http",
+            base_url="https://example.test/mcp",
+            trust_tier="vendorish",  # type: ignore[arg-type]
+        )

--- a/tests/mcp/test_normalize.py
+++ b/tests/mcp/test_normalize.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from mcp.types import CallToolResult, TextContent
+from src.mcp.normalize import normalize_result
+
+
+def test_normalize_result_prefers_structured_content():
+    result = CallToolResult(
+        content=[TextContent(type="text", text='{"ignored": true}')],
+        structuredContent={"data": [{"price": 123.4}]},
+        isError=False,
+    )
+
+    normalized = normalize_result(result, "server", "tool")
+
+    assert normalized["payload_profile"] == "structured_financial"
+    assert normalized["structured_content"] == {"data": [{"price": 123.4}]}
+
+
+def test_normalize_result_parses_json_text():
+    result = CallToolResult(
+        content=[TextContent(type="text", text='{"data": [{"rsi": 54.2}]}')],
+        structuredContent=None,
+        isError=False,
+    )
+
+    normalized = normalize_result(result, "server", "tool")
+
+    assert normalized["payload_profile"] == "structured_financial"
+    assert normalized["parsed_text_json"] == {"data": [{"rsi": 54.2}]}
+
+
+def test_normalize_result_marks_free_text_fallback():
+    result = CallToolResult(
+        content=[TextContent(type="text", text="plain text response")],
+        structuredContent=None,
+        isError=True,
+    )
+
+    normalized = normalize_result(result, "server", "tool")
+
+    assert normalized["payload_profile"] == "free_text"
+    assert normalized["text_content"] == "plain text response"
+    assert normalized["is_error"] is True

--- a/tests/mcp/test_runtime.py
+++ b/tests/mcp/test_runtime.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+from mcp.types import CallToolResult, ListToolsResult, TextContent, Tool
+from src.mcp.catalog import ToolDescriptor
+from src.mcp.client import MCPRuntime
+from src.mcp.config import MCPServerSpec
+from src.mcp.errors import MCPCallError, MCPErrorCategory
+from src.tooling.inspector import InspectionDecision
+
+
+class _FakeSession:
+    def __init__(self, result: CallToolResult | None = None):
+        self._result = result
+
+    async def call_tool(self, name, arguments):
+        assert name
+        assert isinstance(arguments, dict)
+        return self._result
+
+    async def list_tools(self):
+        return ListToolsResult(
+            tools=[
+                Tool(
+                    name="quote",
+                    description="Quote tool",
+                    inputSchema={"type": "object"},
+                    outputSchema={"type": "object"},
+                )
+            ]
+        )
+
+
+class _AllowInspector:
+    async def evaluate(self, envelope):
+        return InspectionDecision(
+            action="allow", threat_level="safe"
+        ), envelope.raw_content
+
+
+class _SanitizeInspector:
+    async def evaluate(self, envelope):
+        return (
+            InspectionDecision(
+                action="sanitize",
+                threat_level="medium",
+                sanitized_content="sanitized text",
+            ),
+            "sanitized text",
+        )
+
+
+class _BlockInspector:
+    async def evaluate(self, envelope):
+        return (
+            InspectionDecision(action="block", threat_level="high", reason="blocked"),
+            "TOOL_BLOCKED: blocked",
+        )
+
+
+def _runtime(tmp_path: Path) -> MCPRuntime:
+    spec = MCPServerSpec(
+        id="fmp_remote",
+        description="FMP",
+        transport="streamable_http",
+        base_url="https://example.test/mcp",
+        scopes=["consultant"],
+        tool_allowlist=["quote"],
+        daily_call_limit=10,
+        per_run_limit=10,
+        trust_tier="official_vendor",
+    )
+    return MCPRuntime([spec], budget_db_path=str(tmp_path / "mcp_usage.db"))
+
+
+@pytest.mark.asyncio
+async def test_call_tool_success_returns_normalized_payload(
+    tmp_path: Path, monkeypatch
+):
+    runtime = _runtime(tmp_path)
+    runtime._inspection_service = _AllowInspector()
+
+    @asynccontextmanager
+    async def fake_open_session(_spec):
+        yield _FakeSession(
+            CallToolResult(
+                content=[TextContent(type="text", text='{"data": [{"price": 12.3}]}')],
+                structuredContent=None,
+                isError=False,
+            )
+        )
+
+    monkeypatch.setattr(runtime, "_open_session", fake_open_session)
+
+    result = await runtime.call_tool(
+        "fmp_remote",
+        "quote",
+        {"symbol": "ABC"},
+        scope="consultant",
+    )
+
+    assert result["parsed_text_json"] == {"data": [{"price": 12.3}]}
+
+
+@pytest.mark.asyncio
+async def test_call_tool_sanitize_returns_text_payload(tmp_path: Path, monkeypatch):
+    runtime = _runtime(tmp_path)
+    runtime._inspection_service = _SanitizeInspector()
+
+    @asynccontextmanager
+    async def fake_open_session(_spec):
+        yield _FakeSession(
+            CallToolResult(
+                content=[TextContent(type="text", text='{"data": [{"price": 12.3}]}')],
+                structuredContent=None,
+                isError=False,
+            )
+        )
+
+    monkeypatch.setattr(runtime, "_open_session", fake_open_session)
+    result = await runtime.call_tool(
+        "fmp_remote",
+        "quote",
+        {"symbol": "ABC"},
+        scope="consultant",
+    )
+    assert result["text_content"] == "sanitized text"
+
+
+@pytest.mark.asyncio
+async def test_call_tool_blocks_inspected_payload_and_records_budget(
+    tmp_path: Path, monkeypatch
+):
+    runtime = _runtime(tmp_path)
+    runtime._inspection_service = _BlockInspector()
+
+    @asynccontextmanager
+    async def fake_open_session(_spec):
+        yield _FakeSession(
+            CallToolResult(
+                content=[TextContent(type="text", text='{"data": [{"price": 12.3}]}')],
+                structuredContent=None,
+                isError=False,
+            )
+        )
+
+    monkeypatch.setattr(runtime, "_open_session", fake_open_session)
+
+    with pytest.raises(MCPCallError) as exc_info:
+        await runtime.call_tool(
+            "fmp_remote",
+            "quote",
+            {"symbol": "ABC"},
+            scope="consultant",
+        )
+
+    assert exc_info.value.category is MCPErrorCategory.INSPECTION
+    assert runtime._budget._run_calls["fmp_remote"] == 1
+
+
+@pytest.mark.asyncio
+async def test_call_tool_rejects_non_allowlisted_tool(tmp_path: Path):
+    runtime = _runtime(tmp_path)
+    with pytest.raises(MCPCallError) as exc_info:
+        await runtime.call_tool(
+            "fmp_remote",
+            "secret_tool",
+            {"symbol": "ABC"},
+            scope="consultant",
+        )
+    assert exc_info.value.category is MCPErrorCategory.CONFIG
+
+
+@pytest.mark.asyncio
+async def test_call_tool_rejects_wrong_scope(tmp_path: Path):
+    runtime = _runtime(tmp_path)
+    with pytest.raises(MCPCallError) as exc_info:
+        await runtime.call_tool(
+            "fmp_remote",
+            "quote",
+            {"symbol": "ABC"},
+            scope="auditor",
+        )
+    assert exc_info.value.category is MCPErrorCategory.CONFIG
+
+
+@pytest.mark.asyncio
+async def test_call_tool_raises_for_upstream_tool_error(tmp_path: Path, monkeypatch):
+    runtime = _runtime(tmp_path)
+    runtime._inspection_service = _AllowInspector()
+
+    @asynccontextmanager
+    async def fake_open_session(_spec):
+        yield _FakeSession(
+            CallToolResult(
+                content=[
+                    TextContent(type="text", text='{"error": "provider said no"}')
+                ],
+                structuredContent=None,
+                isError=True,
+            )
+        )
+
+    monkeypatch.setattr(runtime, "_open_session", fake_open_session)
+
+    with pytest.raises(MCPCallError) as exc_info:
+        await runtime.call_tool(
+            "fmp_remote",
+            "quote",
+            {"symbol": "ABC"},
+            scope="consultant",
+        )
+    assert exc_info.value.category is MCPErrorCategory.TOOL_ERROR
+
+
+@pytest.mark.asyncio
+async def test_list_tools_for_scope_filters_allowlist(tmp_path: Path, monkeypatch):
+    runtime = _runtime(tmp_path)
+
+    @asynccontextmanager
+    async def fake_open_session(_spec):
+        yield _FakeSession()
+
+    monkeypatch.setattr(runtime, "_open_session", fake_open_session)
+    tools = await runtime.list_tools_for_scope("consultant")
+
+    assert tools == [
+        ToolDescriptor(
+            server_id="fmp_remote",
+            name="quote",
+            description="Quote tool",
+            input_schema={"type": "object"},
+            output_schema={"type": "object"},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_open_session_streamable_http_uses_http_client_for_headers(
+    tmp_path: Path, monkeypatch
+):
+    runtime = _runtime(tmp_path)
+    runtime._resolved["fmp_remote"].headers["Authorization"] = "Bearer token"
+    spec = runtime.specs["fmp_remote"]
+    captured: dict[str, object] = {}
+
+    class _FakeAsyncClient:
+        def __init__(self, *, headers=None, follow_redirects=True):
+            captured["headers"] = headers
+            captured["follow_redirects"] = follow_redirects
+
+        async def __aenter__(self):
+            captured["http_client"] = self
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    @asynccontextmanager
+    async def fake_streamable_http_client(url, *, http_client):
+        captured["url"] = url
+        captured["passed_http_client"] = http_client
+        yield "read", "write", None
+
+    class _FakeClientSession:
+        def __init__(self, read, write):
+            captured["read"] = read
+            captured["write"] = write
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def initialize(self):
+            captured["initialized"] = True
+
+    monkeypatch.setattr("src.mcp.client.httpx.AsyncClient", _FakeAsyncClient)
+    monkeypatch.setattr(
+        "src.mcp.client.streamable_http_client",
+        fake_streamable_http_client,
+    )
+    monkeypatch.setattr("src.mcp.client.ClientSession", _FakeClientSession)
+
+    async with runtime._open_session(spec) as session:
+        assert isinstance(session, _FakeClientSession)
+
+    assert captured["headers"] == {"Authorization": "Bearer token"}
+    assert captured["follow_redirects"] is True
+    assert captured["passed_http_client"] is captured["http_client"]
+    assert captured["url"] == "https://example.test/mcp"
+    assert captured["initialized"] is True

--- a/tests/mcp/test_tool_service_integration.py
+++ b/tests/mcp/test_tool_service_integration.py
@@ -1,0 +1,191 @@
+"""End-to-end test that the consultant MCP wrappers route through
+``ToolExecutionService`` so audit, argument-policy, content-inspection, and
+``MCPBudgetHook`` all observe the call under its canonical
+``mcp__<server>__<tool>`` name.
+
+This is the load-bearing assertion for R-2: the MCP path must not bypass the
+shared hook chain.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mcp.types import CallToolResult, TextContent
+from src.consultant_tools import spot_check_metric_mcp_fmp
+from src.mcp.budget import MCPBudgetHook
+from src.mcp.client import MCPRuntime
+from src.mcp.config import MCPServerSpec
+from src.runtime_services import RuntimeServices, use_runtime_services
+from src.tooling.inspection_hook import ContentInspectionHook
+from src.tooling.inspection_service import InspectionService
+from src.tooling.inspector import InspectionDecision, InspectionEnvelope, SourceKind
+from src.tooling.runtime import (
+    ToolExecutionService,
+    ToolHook,
+    ToolInvocation,
+    ToolResult,
+)
+
+
+class _RecordingHook:
+    """A pass-through hook that records the canonical tool names it sees."""
+
+    def __init__(self) -> None:
+        self.before_calls: list[str] = []
+        self.after_calls: list[tuple[str, bool]] = []
+
+    async def before(self, call: ToolInvocation) -> ToolInvocation:
+        self.before_calls.append(call.name)
+        return call
+
+    async def after(self, call: ToolInvocation, result: ToolResult) -> ToolResult:
+        self.after_calls.append((call.name, result.blocked))
+        return result
+
+
+class _RecordingInspector:
+    def __init__(self) -> None:
+        self.envelopes: list[InspectionEnvelope] = []
+
+    async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+        self.envelopes.append(envelope)
+        return InspectionDecision(action="allow", threat_level="safe")
+
+
+def _runtime_with_streaming(tmp_path: Path) -> MCPRuntime:
+    spec = MCPServerSpec(
+        id="fmp_remote",
+        description="FMP",
+        transport="streamable_http",
+        base_url="https://example.test/mcp",
+        scopes=["consultant"],
+        tool_allowlist=["statements"],
+        daily_call_limit=10,
+        per_run_limit=10,
+        trust_tier="official_vendor",
+    )
+    return MCPRuntime([spec], budget_db_path=str(tmp_path / "mcp_usage.db"))
+
+
+@pytest.mark.asyncio
+async def test_consultant_mcp_call_flows_through_tool_service(
+    tmp_path: Path, monkeypatch
+):
+    runtime = _runtime_with_streaming(tmp_path)
+
+    @asynccontextmanager
+    async def fake_open_session(_spec):
+        class _Session:
+            async def call_tool(self, name, arguments):
+                return CallToolResult(
+                    content=[
+                        TextContent(
+                            type="text",
+                            text='{"data": [{"priceEarningsRatio": 14.2}]}',
+                        )
+                    ],
+                    structuredContent=None,
+                    isError=False,
+                )
+
+        yield _Session()
+
+    monkeypatch.setattr(runtime, "_open_session", fake_open_session)
+
+    # Build a real hook chain that includes the budget hook + an inspector hook
+    # plus a recording probe so we can assert on the canonical tool name.
+    inspector = _RecordingInspector()
+    inspection_service = InspectionService(inspector=inspector)
+    recording_hook: ToolHook = _RecordingHook()
+    hooks: list[ToolHook] = [
+        recording_hook,
+        ContentInspectionHook(inspection_service),
+        MCPBudgetHook(runtime),
+    ]
+    tool_service = ToolExecutionService(hooks)
+
+    services = RuntimeServices(
+        tool_service=tool_service,
+        inspection_service=inspection_service,
+        mcp_runtime=runtime,
+    )
+
+    with use_runtime_services(services):
+        # Make get_consultant_tools-style sanity gate happy and exercise the wrapper.
+        with patch(
+            "src.consultant_tools.get_current_runtime_services", return_value=services
+        ):
+            import json
+
+            result = json.loads(
+                await spot_check_metric_mcp_fmp.ainvoke(
+                    {"ticker": "ABC", "metric": "trailingPE"}
+                )
+            )
+
+    assert result["value"] == 14.2
+
+    # The hook chain must have observed the canonical mcp__server__tool name.
+    assert recording_hook.before_calls == ["mcp__fmp_remote__statements"]
+    assert recording_hook.after_calls == [("mcp__fmp_remote__statements", False)]
+
+    # ContentInspectionHook must have built an envelope with the MCP source kind
+    # and the inner tool name (stripped of the mcp__server__ prefix).
+    assert len(inspector.envelopes) == 1
+    envelope = inspector.envelopes[0]
+    assert envelope.source_kind is SourceKind.mcp_tool_output
+    assert envelope.source_name == "fmp_remote"
+    assert envelope.tool_name == "statements"
+    assert envelope.metadata["payload_profile"] == "structured_financial"
+    assert envelope.metadata["trust_tier"] == "official_vendor"
+    assert envelope.metadata["transport"] == "streamable_http"
+
+    # Budget hook must have recorded one upstream consumption for the server.
+    assert runtime.budget._run_calls["fmp_remote"] == 1
+
+
+@pytest.mark.asyncio
+async def test_consultant_mcp_call_blocked_by_budget_returns_failure(
+    tmp_path: Path, monkeypatch
+):
+    runtime = _runtime_with_streaming(tmp_path)
+    # Pre-saturate the per-run limit so the budget hook blocks before the runner.
+    spec = runtime.specs["fmp_remote"]
+    runtime.budget._run_calls["fmp_remote"] = spec.per_run_limit
+
+    @asynccontextmanager
+    async def fake_open_session(_spec):  # pragma: no cover - never invoked when blocked
+        raise AssertionError("runner should not run when budget hook blocks")
+        yield None
+
+    monkeypatch.setattr(runtime, "_open_session", fake_open_session)
+
+    inspection_service = InspectionService()
+    tool_service = ToolExecutionService([MCPBudgetHook(runtime)])
+    services = RuntimeServices(
+        tool_service=tool_service,
+        inspection_service=inspection_service,
+        mcp_runtime=runtime,
+    )
+
+    with use_runtime_services(services):
+        with patch(
+            "src.consultant_tools.get_current_runtime_services", return_value=services
+        ):
+            import json
+
+            result = json.loads(
+                await spot_check_metric_mcp_fmp.ainvoke(
+                    {"ticker": "ABC", "metric": "trailingPE"}
+                )
+            )
+
+    assert result["provider"] == "fmp"
+    assert result["source"] == "fmp_mcp"
+    assert result["failure_kind"] == "budget"
+    assert "budget exhausted" in result["error"].lower()

--- a/tests/test_async_utils.py
+++ b/tests/test_async_utils.py
@@ -1,0 +1,151 @@
+"""Tests for src.async_utils — hard timeouts and pending-task introspection."""
+
+from __future__ import annotations
+
+import asyncio
+import signal
+import time
+
+import pytest
+
+from src.async_utils import (
+    dump_pending_tasks,
+    install_pending_task_dump_handler,
+    run_with_hard_timeout,
+)
+
+
+class TestRunWithHardTimeout:
+    @pytest.mark.asyncio
+    async def test_returns_value_on_success(self):
+        async def quick():
+            await asyncio.sleep(0.01)
+            return 42
+
+        result = await run_with_hard_timeout(quick(), timeout=1.0, label="quick")
+        assert result == 42
+
+    @pytest.mark.asyncio
+    async def test_raises_timeouterror_after_deadline(self):
+        async def slow():
+            await asyncio.sleep(10)
+            return "never"
+
+        with pytest.raises(asyncio.TimeoutError):
+            await run_with_hard_timeout(slow(), timeout=0.05, label="slow")
+
+    @pytest.mark.asyncio
+    async def test_does_not_block_caller_when_inner_ignores_cancellation(self):
+        """Caller must return within the timeout even if the inner task can't be cancelled.
+
+        This is the central guarantee — the bug we're protecting against is
+        ``asyncio.wait_for`` waiting for a cancelled task that never finishes.
+        """
+        inner_started = asyncio.Event()
+
+        async def uncancellable_inner():
+            inner_started.set()
+            try:
+                # Sleep is cancellable, but we explicitly absorb the cancel and
+                # keep going, mimicking a thread blocked in a sync I/O call.
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                await asyncio.sleep(10)  # ignore cancellation, keep blocking
+            return "never"
+
+        start = time.monotonic()
+        with pytest.raises(asyncio.TimeoutError):
+            await run_with_hard_timeout(
+                uncancellable_inner(), timeout=0.1, label="uncancellable"
+            )
+        elapsed = time.monotonic() - start
+        assert elapsed < 1.0, f"caller blocked for {elapsed:.2f}s past timeout"
+        assert inner_started.is_set()
+
+    @pytest.mark.asyncio
+    async def test_orphan_exception_is_silenced(self, caplog):
+        """An inner task that raises after the caller has timed out must not log a warning."""
+
+        async def fail_after_timeout():
+            await asyncio.sleep(0.05)
+            raise RuntimeError("orphan boom")
+
+        with pytest.raises(asyncio.TimeoutError):
+            await run_with_hard_timeout(
+                fail_after_timeout(), timeout=0.01, label="orphan"
+            )
+        # Let the orphan finish; there should be no "Task exception was never
+        # retrieved" warning issued.
+        await asyncio.sleep(0.1)
+
+    @pytest.mark.asyncio
+    async def test_zero_or_negative_timeout_rejected(self):
+        async def noop():
+            return None
+
+        for bad in (0, -1.0):
+            coro = noop()
+            try:
+                with pytest.raises(ValueError):
+                    await run_with_hard_timeout(coro, timeout=bad, label="bad")
+            finally:
+                # run_with_hard_timeout rejects the call before scheduling the
+                # coroutine, so we must close it ourselves to avoid the
+                # "coroutine was never awaited" RuntimeWarning.
+                coro.close()
+
+    @pytest.mark.asyncio
+    async def test_outer_cancellation_propagates(self):
+        async def slow():
+            await asyncio.sleep(10)
+            return "never"
+
+        outer = asyncio.create_task(
+            run_with_hard_timeout(slow(), timeout=10, label="slow")
+        )
+        await asyncio.sleep(0.01)
+        outer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await outer
+
+
+class TestDumpPendingTasks:
+    @pytest.mark.asyncio
+    async def test_records_pending_task(self):
+        async def hold():
+            await asyncio.sleep(1)
+
+        held = asyncio.create_task(hold(), name="hold-me")
+        try:
+            records = dump_pending_tasks()
+            names = [r["name"] for r in records]
+            assert "hold-me" in names
+            entry = next(r for r in records if r["name"] == "hold-me")
+            assert entry["coro"]
+            assert isinstance(entry["stack"], list)
+        finally:
+            held.cancel()
+            try:
+                await held
+            except asyncio.CancelledError:
+                pass
+
+    def test_returns_empty_list_outside_running_loop(self):
+        # No running loop in this sync test => safe empty return.
+        assert dump_pending_tasks() == []
+
+
+class TestInstallPendingTaskDumpHandler:
+    def test_handler_install_and_uninstall_roundtrip(self):
+        if not hasattr(signal, "SIGUSR1"):
+            pytest.skip("SIGUSR1 unavailable on this platform")
+        previous = signal.getsignal(signal.SIGUSR1)
+        uninstall = install_pending_task_dump_handler()
+        try:
+            current = signal.getsignal(signal.SIGUSR1)
+            assert current is not previous
+        finally:
+            uninstall()
+        restored = signal.getsignal(signal.SIGUSR1)
+        # After uninstall, the handler should be removed (back to previous or default).
+        assert restored == previous or restored == signal.SIG_DFL

--- a/tests/test_content_ingress_coverage.py
+++ b/tests/test_content_ingress_coverage.py
@@ -29,6 +29,8 @@ def _has_inspection_call(src: str) -> bool:
     return (
         "INSPECTION_SERVICE.check" in src
         or "get_current_inspection_service().check" in src
+        or "INSPECTION_SERVICE.evaluate" in src
+        or "self._inspection_service.evaluate" in src
     )
 
 
@@ -443,6 +445,13 @@ def test_source_kind_has_memory_write():
     assert SourceKind.memory_write.value == "memory_write"
 
 
+def test_source_kind_has_mcp_tool_output():
+    from src.tooling.inspector import SourceKind
+
+    assert hasattr(SourceKind, "mcp_tool_output")
+    assert SourceKind.mcp_tool_output.value == "mcp_tool_output"
+
+
 # ---------------------------------------------------------------------------
 # 13. New tooling primitives
 # ---------------------------------------------------------------------------
@@ -454,6 +463,16 @@ def test_new_inspectors_importable_from_owning_modules():
     from src.tooling.llm_judge_inspector import LLMJudgeInspector  # noqa: F401
     from src.tooling.text_boundary import format_untrusted_block  # noqa: F401
     from src.tooling.tool_argument_policy import ToolArgumentPolicyHook  # noqa: F401
+
+
+def test_mcp_runtime_uses_mcp_tool_output_inspection():
+    src = _read(_src("mcp/client.py"))
+    assert (
+        "SourceKind.mcp_tool_output" in src
+    ), "mcp/client.py: MCP ingress must use SourceKind.mcp_tool_output."
+    assert _has_inspection_call(
+        src
+    ), "mcp/client.py: MCP tool output must be inspected before prompt reuse."
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fetcher_inflight_cleanup.py
+++ b/tests/test_fetcher_inflight_cleanup.py
@@ -1,0 +1,73 @@
+"""Regression tests for the inflight-dedup leak in SmartMarketDataFetcher.
+
+The fetcher dedups concurrent fetches for the same key by storing an
+``asyncio.Task`` in ``_metrics_inflight`` / ``_history_inflight``. The
+original implementation cleared the slot inside a try/finally around
+``await task``; if the underlying task hung (e.g. a thread blocked on a
+no-timeout socket read), the await never returned and the slot leaked,
+poisoning every subsequent caller for the same ticker.
+
+These tests verify the dedup slot is cleared via ``add_done_callback`` so
+cleanup is independent of the awaiter's progress.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.data.fetcher import SmartMarketDataFetcher
+
+
+@pytest.mark.asyncio
+async def test_metrics_inflight_cleared_when_task_raises():
+    fetcher = SmartMarketDataFetcher.__new__(SmartMarketDataFetcher)
+    # Minimal init for the fields we touch.
+    fetcher._metrics_inflight = {}
+    fetcher._metrics_cache = {}
+    fetcher._metrics_cache_expiry = {}
+
+    async def boom(*_args, **_kwargs):
+        raise RuntimeError("simulated provider failure")
+
+    fetcher._get_financial_metrics_uncached = boom
+
+    with pytest.raises(RuntimeError, match="simulated provider failure"):
+        await fetcher.get_financial_metrics("AAPL", timeout=1)
+
+    # Allow the done-callback (scheduled on the loop) to run.
+    await asyncio.sleep(0)
+    assert (
+        "AAPL" not in fetcher._metrics_inflight
+    ), "inflight slot must be cleared even when the task raised"
+
+
+@pytest.mark.asyncio
+async def test_metrics_inflight_cleared_when_task_cancelled():
+    fetcher = SmartMarketDataFetcher.__new__(SmartMarketDataFetcher)
+    fetcher._metrics_inflight = {}
+    fetcher._metrics_cache = {}
+    fetcher._metrics_cache_expiry = {}
+
+    started = asyncio.Event()
+
+    async def hang(*_args, **_kwargs):
+        started.set()
+        await asyncio.sleep(60)
+        return {}
+
+    fetcher._get_financial_metrics_uncached = hang
+
+    caller = asyncio.create_task(fetcher.get_financial_metrics("AAPL", timeout=1))
+    await started.wait()
+    assert "AAPL" in fetcher._metrics_inflight  # slot is registered
+
+    caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    await asyncio.sleep(0)
+    assert (
+        "AAPL" not in fetcher._metrics_inflight
+    ), "inflight slot must be cleared on cancellation"

--- a/tests/test_main_cli.py
+++ b/tests/test_main_cli.py
@@ -609,6 +609,9 @@ class TestRuntimeServiceHookConfig:
         monkeypatch.setattr(
             "src.main.config.untrusted_content_inspection_enabled", False
         )
+        # Pin MCP off so the assertion only inspects the audit/inspection wiring;
+        # MCP_ENABLED in the operator's .env would otherwise add MCPBudgetHook.
+        monkeypatch.setattr("src.main.config.mcp_enabled", False)
 
         services = build_runtime_services_from_config(enable_tool_audit=False)
         assert services.tool_service.hooks == []
@@ -635,6 +638,70 @@ class TestRuntimeServiceHookConfig:
         hook_types = [type(h).__name__ for h in services.tool_service.hooks]
         assert "LoggingToolAuditHook" in hook_types
         assert "ContentInspectionHook" in hook_types
+
+    def test_build_runtime_services_from_config_builds_mcp_when_inspection_disabled(
+        self, monkeypatch, tmp_path: Path
+    ):
+        from src.main import build_runtime_services_from_config
+
+        registry_path = tmp_path / "mcp_servers.json"
+        registry_path.write_text(
+            json.dumps(
+                {
+                    "servers": [
+                        {
+                            "id": "fmp_remote",
+                            "description": "FMP",
+                            "transport": "streamable_http",
+                            "base_url": "https://example.test/mcp",
+                            "enabled": True,
+                            "scopes": ["consultant"],
+                            "tool_allowlist": ["quote"],
+                            "trust_tier": "official_vendor",
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(
+            "src.main.config.untrusted_content_inspection_enabled", False
+        )
+        monkeypatch.setattr("src.main.config.mcp_enabled", True)
+        monkeypatch.setattr("src.main.config.mcp_servers_path", registry_path)
+        monkeypatch.setattr(
+            "src.main.config.mcp_usage_db_path",
+            tmp_path / "runtime" / "mcp_usage.db",
+        )
+
+        services = build_runtime_services_from_config(enable_tool_audit=False)
+
+        assert services.mcp_runtime is not None
+        hook_types = [type(h).__name__ for h in services.tool_service.hooks]
+        assert "ContentInspectionHook" not in hook_types
+        assert "MCPBudgetHook" in hook_types
+
+    def test_build_runtime_services_from_config_degrades_when_mcp_registry_missing(
+        self, monkeypatch, tmp_path: Path
+    ):
+        from src.main import build_runtime_services_from_config
+
+        monkeypatch.setattr("src.main.config.mcp_enabled", True)
+        monkeypatch.setattr(
+            "src.main.config.mcp_servers_path",
+            tmp_path / "missing_mcp_servers.json",
+        )
+        monkeypatch.setattr(
+            "src.main.config.mcp_usage_db_path",
+            tmp_path / "runtime" / "mcp_usage.db",
+        )
+
+        services = build_runtime_services_from_config(enable_tool_audit=False)
+
+        assert services.mcp_runtime is None
+        hook_types = [type(h).__name__ for h in services.tool_service.hooks]
+        assert "MCPBudgetHook" not in hook_types
 
     def test_configure_content_inspection_from_config_installs_tool_hook(
         self, monkeypatch

--- a/tests/tooling/test_inspection_hook.py
+++ b/tests/tooling/test_inspection_hook.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import pytest
 
+from src.mcp.client import MCPRuntime
+from src.mcp.config import MCPServerSpec
+from src.runtime_services import RuntimeServices, use_runtime_services
 from src.tooling.inspection_hook import ContentInspectionHook
 from src.tooling.inspection_service import INSPECTION_SERVICE, InspectionService
 from src.tooling.inspector import (
@@ -12,7 +15,7 @@ from src.tooling.inspector import (
     NullInspector,
     SourceKind,
 )
-from src.tooling.runtime import ToolInvocation, ToolResult
+from src.tooling.runtime import ToolExecutionService, ToolInvocation, ToolResult
 
 
 def _invocation(name: str = "test_tool", source: str = "toolnode") -> ToolInvocation:
@@ -206,6 +209,56 @@ async def test_envelope_populated_from_invocation():
         assert env.content_text == "content"
     finally:
         INSPECTION_SERVICE.configure(original_inspector, mode=original_mode)
+
+
+@pytest.mark.asyncio
+async def test_mcp_envelope_includes_payload_profile_and_trust_tier(tmp_path):
+    captured: list[InspectionEnvelope] = []
+
+    class CapturingInspector:
+        async def inspect(self, envelope: InspectionEnvelope) -> InspectionDecision:
+            captured.append(envelope)
+            return InspectionDecision(action="allow", threat_level="safe")
+
+    runtime = MCPRuntime(
+        [
+            MCPServerSpec(
+                id="fmp_remote",
+                description="FMP",
+                transport="streamable_http",
+                base_url="https://example.test/mcp",
+                scopes=["consultant"],
+                tool_allowlist=["ratios"],
+                trust_tier="official_vendor",
+            )
+        ],
+        budget_db_path=str(tmp_path / "mcp_usage.db"),
+    )
+    inspection_service = InspectionService(CapturingInspector(), mode="warn")
+    services = RuntimeServices(
+        tool_service=ToolExecutionService([]),
+        inspection_service=inspection_service,
+        mcp_runtime=runtime,
+    )
+
+    with use_runtime_services(services):
+        hook = ContentInspectionHook(inspection_service)
+        result = await hook.after(
+            _invocation(name="mcp__fmp_remote__ratios", source="consultant"),
+            ToolResult(
+                value={
+                    "payload_profile": "structured_financial",
+                    "structured_content": {"data": [{"priceEarningsRatio": 14.2}]},
+                }
+            ),
+        )
+
+    assert result.blocked is False
+    assert len(captured) == 1
+    metadata = captured[0].metadata or {}
+    assert metadata["payload_profile"] == "structured_financial"
+    assert metadata["trust_tier"] == "official_vendor"
+    assert metadata["transport"] == "streamable_http"
 
 
 @pytest.mark.asyncio

--- a/tests/tooling/test_inspection_service.py
+++ b/tests/tooling/test_inspection_service.py
@@ -187,6 +187,22 @@ async def test_fail_closed_blocks_on_backend_error():
     assert result.startswith("TOOL_BLOCKED:")
 
 
+@pytest.mark.asyncio
+async def test_evaluate_returns_decision_and_original_content():
+    svc = InspectionService(NullInspector(), mode="warn")
+    decision, approved = await svc.evaluate(_envelope("content"))
+    assert decision.action == "allow"
+    assert approved == "content"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_returns_decision_and_blocked_placeholder():
+    svc = InspectionService(_BlockingInspector(), mode="block")
+    decision, approved = await svc.evaluate(_envelope("content"))
+    assert decision.action == "block"
+    assert approved.startswith("TOOL_BLOCKED:")
+
+
 # ---------------------------------------------------------------------------
 # CompositeInspector strategies
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary                                                                                                                                       
                                         
  Adds MCP (Model Context Protocol) integration so the consultant agent can cross-validate analyst claims against vendor MCP servers (FMP) under the same audit/argument-policy/inspection/budget hook chain as every other tool. Bundles a hang-prevention overhaul of the tool execution +  parallel data-fetch paths that surfaced while smoke-testing.                                                                                     
                                                            
## What's in this PR

### MCP integration (`src/mcp/`)

  - New package: validated `MCPServerSpec`/`MCPAuthSpec`, streamable-HTTP + stdio transports, `MCPRuntime` with `execute_raw()` (hook-chain runner)
   and `call_tool()` (convenience), structured `MCPCallError` + `MCPErrorCategory` + `classify_mcp_error()`, `MCPBudgetHook` (SQLite-backed per-server quotas), `ToolCatalog` populated from `tools/list`, payload normalizer.
  - Consultant wrappers in `src/consultant_tools.py` route through `get_current_tool_service().execute()` under the canonical `mcp__<server>__<tool>` name. `_FMP_METRIC_DISPATCH` maps each metric to a `(tool, endpoint)` tuple matching FMP's dispatcher pattern, verified empirically via `tools/list`. `is_error=true` payloads now surface vendor error text as `failure_kind="tool_error"` instead of opaque shape errors.                                                                                                                                          
  - Twelve Data MCP intentionally excluded — its public surface is only `u-tool` (free-form AI router) and `doc-tool`, neither of which fits the narrow-allowlist contract. Registry entry left with `enabled: false` + explanation.                                                              

### Hang prevention (`src/async_utils.py`, hot paths)
                                                                       
  - `run_with_hard_timeout()` — orphan-on-timeout pattern; raises `TimeoutError` immediately and lets the inner task die in the background, instead of `asyncio.wait_for`'s blocking-on-cancellation behavior. The original cause of multi-tool 32-min hangs in tool fan-out was uncancellable `asyncio.to_thread`-wrapped sync I/O blocking `wait_for`'s cleanup forever.
  - Migrated network-bound timeouts to use it: `ToolExecutionService.execute()`, `data/source_fetchers.fetch_all_sources_parallel()`, `tavily_utils`, `tools/shared.fetch_with_timeout`, `_ddg_search`.                                                                                
  - `fetch_all_sources_parallel()` rewritten from a sequential `for ... await wait_for` loop to actual `asyncio.gather` so one slow provider can't block siblings.                                                                                                                                  
  - Inflight dedup leak in `SmartMarketDataFetcher` (`_metrics_inflight`, `_history_inflight`) fixed via `task.add_done_callback` so the dedup map clears regardless of whether anyone is still awaiting — a single hung underlying fetch can no longer poison subsequent calls for the same ticker.
  - `install_pending_task_dump_handler()` adds a SIGUSR1 handler — `kill -USR1 <pid>` dumps every pending asyncio task with stack on a hung run.
                                                                                                                                                   
### Config / env hardening
                                
  - `src/config.py:get_env_value()` resolves env vars by name with shell-precedence + `.env` fallback. `src/mcp/auth.py` now uses it instead of raw `os.getenv`, so MCP keys defined only in `.env` are visible (the original code only saw shell-exported values, breaking MCP for everyone running with `.env`-only credentials).                                                                                                                  
  - MCP runtime initialization is independent of the global content-inspection flag.                                                               
  - `MCPCallError` traceback no longer logged at ERROR with `exc_info=True` — only the redacted message.                                           
                                                                                                                                                   
### Diagnostics
                                                                                                                               
  - `scripts/mcp_smoke.py` — permanent CLI diagnostic (argparse, CI exit codes 0/1/2/3, structured JSON to stdout). Bypasses the consultant LLM and exercises the full hook chain → MCP transport → vendor in ~5s. Use any time the question is "is MCP actually moving bytes?".                    
                                                                                                                                                   
### Documentation
                                                                                                                          
  - `docs/MCP.md` (new) — registry schema, trust-tier vocabulary, scope semantics, vendor surface notes, smoke-testing recipe, failure-kind decoder.                                                                                                                                         
  - `CLAUDE.md` — MCP integration section, env-var resolution pattern (`get_env_value` for data-driven keys), pointer to the smoke test.
  - `README.md` — corrected stale Twelve Data claim, added smoke-test pointer.                                                                     
  - `config/mcp_servers.example.json` — example registry with both servers (FMP enabled, Twelve Data disabled with explanation).                   
                                                                                                                                                   
## Test plan                                                                                                                                     
                                                                                                                                                   
  - [ ] `poetry run ruff check src/ tests/ scripts/` clean  
  - [ ] `poetry run mypy src/mcp/ src/consultant_tools.py src/runtime_services.py src/tooling/runtime.py src/async_utils.py scripts/mcp_smoke.py`  clean                                                                                                                                            
  - [ ] `poetry run pytest tests/mcp tests/agents/test_consultant_tools.py tests/test_main_cli.py tests/test_async_utils.py                        
  tests/test_fetcher_inflight_cleanup.py tests/tooling -q` (387 passing locally)                                                                   
  - [ ] Smoke against live FMP: `poetry run python scripts/mcp_smoke.py --ticker AAPL --metric currentPrice` — expect exit 0 with `value` populated on a paid plan, exit 1 with `failure_kind="tool_error"` HTTP 402 on free tier (the integration is healthy in both cases; 402 = vendor billing, not a code bug)                                           
  - [ ] Full analysis without `--quick` (≈4 min, ~$0.20): `poetry run python -m src.main --ticker 6914.T --verbose --output                        
  scratch/<ticker>-<date>.md` — verify `mcp_runtime_initialized server_count=1`, `consultant_llm_init`, `consultant_review_complete has_errors=False`, zero `hard_timeout_exceeded` / `tool_call_runner_failed` events, JSON artifact written to `results/`
  - [ ] Hang resilience: kill the run with `kill -USR1 <pid>` mid-flight → expect `pending_tasks_dump` log entry with one record per in-flight asyncio task                                                                                                                                     
       
## Notes                                                                                                                                         
                                                            
  - Bottom-tier FMP plans will see HTTP 402 on most metrics; integration is plumbed correctly but data-dormant until plan upgrade. Consultant has fallback paths (`spot_check_metric_alt`, `get_official_filings`) regardless.                                                                     
  - Documented sandbox limitation: `poetry run python -m src.main` cannot run inside the Claude Code execution environment (`socksio` ImportError).  Run on a normal shell.                                                                                                                          
